### PR TITLE
feat: centralize API base URL

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = "https://api.tasks.fineko.space/api";

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import axios from "axios";
+import { API_BASE_URL } from "../config";
 
 const AuthContext = createContext(null);
 
@@ -22,7 +23,7 @@ export function AuthProvider({ children }) {
   const login = async (username, password) => {
     try {
       const res = await axios.post(
-        "https://tasks.fineko.space/api/auth/login",
+        `${API_BASE_URL}/auth/login`,
         { username, password },
         {
           withCredentials: true,
@@ -42,7 +43,7 @@ export function AuthProvider({ children }) {
   const logout = async () => {
     try {
       await axios.post(
-        "https://tasks.fineko.space/api/auth/logout",
+        `${API_BASE_URL}/auth/logout`,
         {},
         {
           withCredentials: true,

--- a/src/modules/auth/pages/ForgotPasswordPage.jsx
+++ b/src/modules/auth/pages/ForgotPasswordPage.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import axios from "axios";
+import { API_BASE_URL } from "../../../config";
 import AuthLayout from "../../../components/layout/AuthLayout/AuthLayout";
 import "./LoginPage.css";
 
@@ -16,7 +17,7 @@ export default function ForgotPasswordPage() {
         setMessage("");
         try {
             const res = await axios.post(
-                "https://tasks.fineko.space/api/auth/request-password-reset",
+                `${API_BASE_URL}/auth/request-password-reset`,
                 { email }
             );
             if (res.data && res.data.success) {

--- a/src/modules/auth/pages/ResetPasswordPage.jsx
+++ b/src/modules/auth/pages/ResetPasswordPage.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import axios from "axios";
+import { API_BASE_URL } from "../../../config";
 import AuthLayout from "../../../components/layout/AuthLayout/AuthLayout";
 import "./LoginPage.css";
 
@@ -17,7 +18,7 @@ export default function ResetPasswordPage() {
         setMessage("");
         try {
             const res = await axios.post(
-                "https://tasks.fineko.space/api/auth/reset-password",
+                `${API_BASE_URL}/auth/reset-password`,
                 { token, password }
             );
             if (res.data && res.data.success) {

--- a/src/modules/orgStructure/pages/OrgStructurePage.jsx
+++ b/src/modules/orgStructure/pages/OrgStructurePage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Layout from "../../../components/layout/Layout";
 import axios from "axios";
+import { API_BASE_URL } from "../../../config";
 
 export default function OrgStructurePage() {
     const [tree, setTree] = useState([]);
@@ -10,10 +11,10 @@ export default function OrgStructurePage() {
             try {
                 const [posRes, userRes] = await Promise.all([
                     axios.get(
-                        "https://tasks.fineko.space/api/position"
+                        `${API_BASE_URL}/position`
                     ),
                     axios.get(
-                        "https://tasks.fineko.space/api/user"
+                        `${API_BASE_URL}/user`
                     ),
                 ]);
                 const positions = posRes.data;

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import Layout from "../../../components/layout/Layout";
 import "./DailyTasksPage.css";
 import axios from "axios";
+import { API_BASE_URL } from "../../../config";
 
 import TaskFilters from "../components/TaskFilters";
 import TaskItem from "../components/TaskItem";
@@ -32,7 +33,7 @@ export default function DailyTasksPage() {
 
         axios
             .get(
-                `https://tasks.fineko.space/api/task/filter?${params.toString()}`
+                `${API_BASE_URL}/task/filter?${params.toString()}`
             )
             .then((res) => {
                 if (res.data && res.data.tasks) {
@@ -66,7 +67,7 @@ export default function DailyTasksPage() {
     const deleteTask = async (id) => {
         try {
             await axios.delete(
-                `https://tasks.fineko.space/api/task/delete?id=${id}`
+                `${API_BASE_URL}/task/delete?id=${id}`
             );
             setTasks((prev) => prev.filter((task) => task.id !== id));
         } catch (err) {
@@ -80,7 +81,7 @@ export default function DailyTasksPage() {
     const updateTaskField = async (id, field, value) => {
         try {
             const res = await axios.patch(
-                `https://tasks.fineko.space/api/task/update-field?id=${id}`,
+                `${API_BASE_URL}/task/update-field?id=${id}`,
                 { field, value }
             );
 


### PR DESCRIPTION
## Summary
- add config for shared API base
- refactor API calls to use shared base

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688cf7d60c9483329fe16fd64dc69eb2