### PR TITLE
feat: apply global styles and layout structure

### DIFF
--- a/src/components/layout/Footer/Footer.css
+++ b/src/components/layout/Footer/Footer.css
@@ -1,6 +1,7 @@
 .footer {
-    background: #f0f0f0;
+    background: var(--surface);
+    border-top: 1px solid var(--border);
     padding: 10px;
     text-align: center;
-    font-size: 14px;
+    font-size: var(--fz-sm);
 }

--- a/src/components/layout/Header/Header.css
+++ b/src/components/layout/Header/Header.css
@@ -1,14 +1,15 @@
 .app-header {
-    height: 50px;
-    background: #1e1e1e;
-    /* темна шапка */
-    color: #fff;
+    height: var(--header-height);
+    background: var(--surface);
+    color: var(--text);
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 15px;
-    position: relative;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    padding: 0 20px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    border-bottom: 1px solid var(--border);
 }
 
 /* Ліва частина: меню */
@@ -18,7 +19,9 @@
     cursor: pointer;
     display: flex;
     align-items: center;
+    color: var(--navy);
 }
+
 .header-left .org-name {
     margin-left: 10px;
     font-weight: bold;
@@ -32,24 +35,8 @@
 }
 
 .search-input {
-    width: 50%;
+    width: 100%;
     max-width: 400px;
-    padding: 6px 12px;
-    border-radius: 4px;
-    border: none;
-    outline: none;
-    background: #2c2c2c;
-    color: #fff;
-    font-size: 14px;
-    transition: 0.2s;
-}
-
-.search-input:focus {
-    background: #333;
-}
-
-.search-input::placeholder {
-    color: #aaa;
 }
 
 /* Права частина: аватар */
@@ -60,7 +47,7 @@
 }
 
 .user-avatar {
-    background: #ff9900;
+    background: var(--primary);
     color: #000;
     width: 32px;
     height: 32px;
@@ -76,13 +63,13 @@
 /* Дропдаун-меню */
 .user-dropdown {
     position: absolute;
-    top: 45px;
+    top: calc(var(--header-height) + 4px);
     right: 0;
-    background: #2a2a2a;
-    border: 1px solid #444;
-    border-radius: 6px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
     min-width: 150px;
-    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
+    box-shadow: var(--shadow);
     z-index: 10;
 }
 
@@ -94,15 +81,16 @@
 
 .user-dropdown li {
     padding: 10px 15px;
-    color: #ddd;
+    color: var(--text);
     cursor: pointer;
-    transition: 0.2s;
+    transition: background var(--transition);
 }
 
 .user-dropdown li:hover {
-    background: #3a3a3a;
+    background: var(--bg);
 }
 
 .user-dropdown .logout {
-    color: #ff6666;
+    color: var(--critical);
 }
+

--- a/src/components/layout/Header/Header.jsx
+++ b/src/components/layout/Header/Header.jsx
@@ -12,14 +12,14 @@ export default function Header({ onToggleMenu }) {
             {/* Ліва частина: кнопка відкриття/закриття меню */}
             <div className="header-left">
                 <button className="menu-btn" onClick={onToggleMenu} title="Toggle menu">
-                    <FiMenu size={22} color="#fff" />
+                    <FiMenu size={22} />
                 </button>
                 {user && <span className="org-name">{user.organization?.name}</span>}
             </div>
 
             {/* Центр: пошук */}
             <div className="header-center">
-                <input type="text" className="search-input" placeholder="Знайти задачі..." />
+                <input type="text" className="search-input input" placeholder="Знайти задачі..." />
             </div>
 
             {/* Права частина: аватар */}

--- a/src/components/layout/Layout.css
+++ b/src/components/layout/Layout.css
@@ -1,32 +1,26 @@
 .layout {
+    display: grid;
+    grid-template-columns: var(--sidebar-width) 1fr;
+    height: 100vh;
+    background: var(--bg);
+}
+
+.layout.collapsed-sidebar {
+    grid-template-columns: var(--sidebar-collapsed) 1fr;
+}
+
+.layout-column {
     display: flex;
     flex-direction: column;
     height: 100vh;
+    overflow: hidden;
 }
 
-/* Область хедера + сайдбара + контенту */
-.layout-body {
-    display: flex;
-    flex: 1;
-    transition: all 0.3s ease;
-    padding-top: 0;
-}
-
-/* Контент */
 .layout-content {
     flex: 1;
+    min-height: 0;
+    overflow-y: auto;
     padding: 20px;
-    background: #fff;
-    transition: all 0.3s ease;
-    min-height: 100vh;
+    background: var(--bg);
 }
 
-/* Якщо меню закрите – відступ мінімальний (60px) */
-.layout-body.collapsed-sidebar .layout-content {
-    margin-left: 60px;
-}
-
-/* Якщо меню відкрите – контент звужується (220px) */
-.layout-body.with-sidebar .layout-content {
-    margin-left: 220px;
-}

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -8,16 +8,13 @@ export default function Layout({ children }) {
     const [menuOpen, setMenuOpen] = useState(false);
 
     return (
-        <div className="layout">
-            <Header onToggleMenu={() => setMenuOpen(!menuOpen)} />
-            <div
-                className={`layout-body ${menuOpen ? "with-sidebar" : "collapsed-sidebar"
-                    }`}
-            >
-                <Sidebar isOpen={menuOpen} onToggle={() => setMenuOpen(!menuOpen)} />
+        <div className={`layout ${menuOpen ? "" : "collapsed-sidebar"}`}>
+            <Sidebar isOpen={menuOpen} onToggle={() => setMenuOpen(!menuOpen)} />
+            <div className="layout-column">
+                <Header onToggleMenu={() => setMenuOpen(!menuOpen)} />
                 <main className="layout-content">{children}</main>
+                <Footer />
             </div>
-            <Footer />
         </div>
     );
 }

--- a/src/components/layout/Sidebar/Sidebar.css
+++ b/src/components/layout/Sidebar/Sidebar.css
@@ -1,24 +1,19 @@
 .sidebar {
-    background: #ff6600;
+    background: var(--primary);
     color: #fff;
-    height: 100vh;
-    transition: width 0.3s ease;
+    height: 100%;
+    transition: width var(--transition);
     overflow: hidden;
-    position: fixed;
-    left: 0;
-    top: 0;
-    z-index: 10;
     display: flex;
     flex-direction: column;
 }
 
 .sidebar.collapsed {
-    width: 60px;
+    width: var(--sidebar-collapsed);
 }
 
 .sidebar.expanded {
-    width: 220px;
-    background: #f60;
+    width: var(--sidebar-width);
 }
 
 /* Верхня панель */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,16 @@
 @import "./variables.css";
 
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
 html,
 body,
 #root {
     height: 100%;
+    margin: 0;
     background: var(--bg);
     color: var(--text);
     font-family: Inter, "Open Sans", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
@@ -51,6 +58,11 @@ a {
     box-shadow: 0 10px 24px rgba(17, 24, 39, 0.08);
 }
 
+.btn:disabled {
+    opacity: .6;
+    cursor: not-allowed;
+}
+
 .btn.primary {
     background: var(--primary);
     border-color: var(--primary);
@@ -69,7 +81,7 @@ a {
     padding: 4px 10px;
     border: 1px solid var(--border);
     font-size: var(--fz-sm);
-    background: #fff;
+    background: var(--surface);
 }
 
 .badge.critical {
@@ -92,7 +104,7 @@ a {
 }
 
 .row-hover:hover {
-    background: #fff;
+    background: var(--surface);
     box-shadow: var(--shadow);
 }
 
@@ -119,7 +131,7 @@ a {
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     font-size: var(--fz-base);
-    background: #fff;
+    background: var(--surface);
     color: var(--text);
     transition: border-color var(--transition), box-shadow var(--transition);
 }
@@ -154,6 +166,6 @@ a {
 }
 
 .table tr:hover {
-    background: #fff;
+    background: var(--surface);
     box-shadow: var(--shadow);
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -32,4 +32,8 @@
     --fz-h: 25px;
     /* заголовки */
     --transition: 160ms ease;
+
+    --sidebar-width: 260px;
+    --sidebar-collapsed: 60px;
+    --header-height: 56px;
 }


### PR DESCRIPTION
## Summary
- add design tokens for sidebar and header and reset base styles
- implement grid layout with sticky header/footer and scrollable main
- align header, sidebar and footer with light theme variables

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_689a16b1f1d4833297113c3f96aae189