### PR TITLE
feat: add sidebar triggers and search in header

### DIFF
--- a/src/components/layout/Header/Header.css
+++ b/src/components/layout/Header/Header.css
@@ -12,46 +12,72 @@
     border-bottom: 1px solid var(--border);
 }
 
-/* Ліва частина: меню */
-.header-left .menu-btn {
-    background: none;
-    border: none;
-    cursor: pointer;
+.header-left,
+.header-right {
     display: flex;
     align-items: center;
-    color: var(--navy);
+    gap: 12px;
 }
 
-.header-left .org-name {
-    margin-left: 10px;
-    font-weight: bold;
-}
-
-/* Центр: пошук */
 .header-center {
     flex: 1;
     display: flex;
     justify-content: center;
 }
 
-.search-input {
+.header-search {
+    position: relative;
     width: 100%;
     max-width: 400px;
 }
 
-/* Права частина: аватар */
-.header-right {
-    position: relative;
+.header-search .search-icon {
+    position: absolute;
+    top: 50%;
+    left: 12px;
+    transform: translateY(-50%);
+    color: #9CA3AF;
+    pointer-events: none;
+}
+
+.header-search .input {
+    width: 100%;
+    padding-left: 36px;
+}
+
+.icon-btn {
     display: flex;
     align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    cursor: pointer;
+    transition: transform var(--transition), background var(--transition);
+}
+
+.icon-btn:hover {
+    transform: translateY(-1px);
+    background: var(--bg);
+}
+
+.icon-btn:active {
+    transform: translateY(1px);
+}
+
+.header-right {
+    position: relative;
 }
 
 .user-avatar {
     background: var(--primary);
     color: #000;
-    width: 32px;
-    height: 32px;
+    width: 36px;
+    height: 36px;
     border-radius: 50%;
+    border: 1px solid var(--border);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -60,7 +86,6 @@
     cursor: pointer;
 }
 
-/* Дропдаун-меню */
 .user-dropdown {
     position: absolute;
     top: calc(var(--header-height) + 4px);

--- a/src/components/layout/Header/Header.jsx
+++ b/src/components/layout/Header/Header.jsx
@@ -1,38 +1,76 @@
 import React, { useState } from "react";
 import "./Header.css";
-import { FiMenu } from "react-icons/fi"; // стильна іконка меню
+import { FiMenu, FiSearch, FiCheckSquare } from "react-icons/fi";
 import { useAuth } from "../../../context/AuthContext";
 
-export default function Header({ onToggleMenu }) {
+export default function Header() {
     const [userMenuOpen, setUserMenuOpen] = useState(false);
     const { user, logout } = useAuth();
 
+    const handleLeftToggle = () => {
+        window.dispatchEvent(new CustomEvent("ui:toggleLeftSidebar"));
+    };
+
+    const handleRightToggle = () => {
+        window.dispatchEvent(new CustomEvent("ui:toggleRightSidebar"));
+    };
+
+    const initials = user?.name
+        ? user.name
+              .split(" ")
+              .map((n) => n[0])
+              .join("")
+              .toUpperCase()
+        : "";
+
     return (
         <header className="app-header">
-            {/* Ліва частина: кнопка відкриття/закриття меню */}
             <div className="header-left">
-                <button className="menu-btn" onClick={onToggleMenu} title="Toggle menu">
-                    <FiMenu size={22} />
+                <button
+                    className="icon-btn"
+                    aria-label="Відкрити меню"
+                    onClick={handleLeftToggle}
+                    type="button"
+                >
+                    <FiMenu size={20} />
                 </button>
-                {user && <span className="org-name">{user.organization?.name}</span>}
             </div>
 
-            {/* Центр: пошук */}
             <div className="header-center">
-                <input type="text" className="search-input input" placeholder="Знайти задачі..." />
+                <div className="header-search">
+                    <FiSearch className="search-icon" />
+                    <input
+                        type="text"
+                        className="input"
+                        placeholder="Пошук..."
+                    />
+                </div>
             </div>
 
-            {/* Права частина: аватар */}
             <div className="header-right">
-                <div className="user-avatar" onClick={() => setUserMenuOpen(!userMenuOpen)}>
-                    AD
+                <button
+                    className="icon-btn"
+                    aria-label="Задачі на сьогодні"
+                    onClick={handleRightToggle}
+                    type="button"
+                >
+                    <FiCheckSquare size={20} />
+                </button>
+                <button className="btn ghost" type="button">Open Telegram</button>
+                <div
+                    className="user-avatar"
+                    onClick={() => setUserMenuOpen(!userMenuOpen)}
+                >
+                    {initials}
                 </div>
                 {userMenuOpen && (
                     <div className="user-dropdown">
                         <ul>
                             <li>Профіль</li>
                             <li>Налаштування</li>
-                            <li className="logout" onClick={logout}>Вихід</li>
+                            <li className="logout" onClick={logout}>
+                                Вихід
+                            </li>
                         </ul>
                     </div>
                 )}

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -11,7 +11,7 @@ export default function Layout({ children }) {
         <div className={`layout ${menuOpen ? "" : "collapsed-sidebar"}`}>
             <Sidebar isOpen={menuOpen} onToggle={() => setMenuOpen(!menuOpen)} />
             <div className="layout-column">
-                <Header onToggleMenu={() => setMenuOpen(!menuOpen)} />
+                <Header />
                 <main className="layout-content">{children}</main>
                 <Footer />
             </div>


### PR DESCRIPTION
## Summary
- add icon buttons to toggle left and right sidebars via custom events
- implement centered search input with icon and styling
- show Telegram button and bordered avatar in header

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_689a1d2eefd083328ca862ecf403d990