### PR TITLE
feat: add dual sidebar layout

### DIFF
--- a/src/components/layout/Layout.css
+++ b/src/components/layout/Layout.css
@@ -1,19 +1,24 @@
 .layout {
-    display: grid;
-    grid-template-columns: var(--sidebar-width) 1fr;
-    height: 100vh;
+    position: relative;
+    min-height: 100vh;
     background: var(--bg);
-}
-
-.layout.collapsed-sidebar {
-    grid-template-columns: var(--sidebar-collapsed) 1fr;
 }
 
 .layout-column {
     display: flex;
     flex-direction: column;
-    height: 100vh;
-    overflow: hidden;
+    min-height: 100vh;
+    margin-left: 0;
+    margin-right: 0;
+    transition: margin var(--transition);
+}
+
+.layout.left-open .layout-column {
+    margin-left: var(--sidebar-width);
+}
+
+.layout.right-open .layout-column {
+    margin-right: var(--sidebar-width);
 }
 
 .layout-content {
@@ -21,6 +26,54 @@
     min-height: 0;
     overflow-y: auto;
     padding: 20px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+}
+
+/* sidebar handles */
+.sidebar-handle {
+    position: fixed;
+    top: 50%;
+    width: 16px;
+    height: 80px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    z-index: 110;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background var(--transition);
+}
+
+.sidebar-handle:hover {
     background: var(--bg);
+}
+
+.sidebar-handle::before {
+    content: "";
+    width: 4px;
+    height: 24px;
+    background: repeating-linear-gradient(
+        to right,
+        var(--border),
+        var(--border) 1px,
+        transparent 1px,
+        transparent 2px
+    );
+    border-radius: 2px;
+}
+
+.sidebar-handle-left {
+    left: 0;
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.sidebar-handle-right {
+    right: 0;
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
 }
 

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,20 +1,85 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Header from "./Header/Header";
 import Sidebar from "./Sidebar/Sidebar";
 import Footer from "./Footer/Footer";
 import "./Layout.css";
 
 export default function Layout({ children }) {
-    const [menuOpen, setMenuOpen] = useState(false);
+    const [leftOpen, setLeftOpen] = useState(false);
+    const [rightOpen, setRightOpen] = useState(false);
+
+    /* restore state */
+    useEffect(() => {
+        const left = localStorage.getItem("layout-left-open") === "1";
+        const right = localStorage.getItem("layout-right-open") === "1";
+        if (left && right) {
+            setLeftOpen(true);
+            setRightOpen(false);
+        } else {
+            setLeftOpen(left);
+            setRightOpen(right);
+        }
+    }, []);
+
+    useEffect(() => {
+        localStorage.setItem("layout-left-open", leftOpen ? "1" : "0");
+    }, [leftOpen]);
+
+    useEffect(() => {
+        localStorage.setItem("layout-right-open", rightOpen ? "1" : "0");
+    }, [rightOpen]);
+
+    const toggleLeft = useCallback(() => {
+        setLeftOpen((prev) => {
+            const next = !prev;
+            if (next) setRightOpen(false);
+            return next;
+        });
+    }, []);
+
+    const toggleRight = useCallback(() => {
+        setRightOpen((prev) => {
+            const next = !prev;
+            if (next) setLeftOpen(false);
+            return next;
+        });
+    }, []);
+
+    /* custom event listeners */
+    useEffect(() => {
+        const handleLeft = () => toggleLeft();
+        const handleRight = () => toggleRight();
+        window.addEventListener("ui:toggleLeftSidebar", handleLeft);
+        window.addEventListener("ui:toggleRightSidebar", handleRight);
+        return () => {
+            window.removeEventListener("ui:toggleLeftSidebar", handleLeft);
+            window.removeEventListener("ui:toggleRightSidebar", handleRight);
+        };
+    }, [toggleLeft, toggleRight]);
 
     return (
-        <div className={`layout ${menuOpen ? "" : "collapsed-sidebar"}`}>
-            <Sidebar isOpen={menuOpen} onToggle={() => setMenuOpen(!menuOpen)} />
+        <div
+            className={`layout ${leftOpen ? "left-open" : ""} ${rightOpen ? "right-open" : ""}`}
+            style={{ "--left-open": leftOpen ? 1 : 0, "--right-open": rightOpen ? 1 : 0 }}
+        >
+            <Sidebar position="left" isOpen={leftOpen} onToggle={toggleLeft} />
+            <Sidebar position="right" isOpen={rightOpen} onToggle={toggleRight} />
+            <button
+                className="sidebar-handle sidebar-handle-left"
+                aria-label="Toggle left sidebar"
+                onClick={toggleLeft}
+            />
+            <button
+                className="sidebar-handle sidebar-handle-right"
+                aria-label="Toggle right sidebar"
+                onClick={toggleRight}
+            />
             <div className="layout-column">
-                <Header onToggleMenu={() => setMenuOpen(!menuOpen)} />
+                <Header onToggleMenu={toggleLeft} />
                 <main className="layout-content">{children}</main>
                 <Footer />
             </div>
         </div>
     );
 }
+

--- a/src/components/layout/Sidebar/Sidebar.css
+++ b/src/components/layout/Sidebar/Sidebar.css
@@ -1,19 +1,30 @@
 .sidebar {
-    background: var(--primary);
-    color: #fff;
-    height: 100%;
-    transition: width var(--transition);
-    overflow: hidden;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: var(--sidebar-width);
+    background: var(--surface);
+    color: var(--text);
+    box-shadow: var(--shadow);
+    overflow-y: auto;
     display: flex;
     flex-direction: column;
+    transition: transform var(--transition);
+    z-index: 100;
 }
 
-.sidebar.collapsed {
-    width: var(--sidebar-collapsed);
+.sidebar.left {
+    left: 0;
+    transform: translateX(-100%);
+}
+
+.sidebar.right {
+    right: 0;
+    transform: translateX(100%);
 }
 
 .sidebar.expanded {
-    width: var(--sidebar-width);
+    transform: translateX(0);
 }
 
 /* Верхня панель */
@@ -28,7 +39,7 @@
 .sidebar-toggle {
     background: none;
     border: none;
-    color: #fff;
+    color: inherit;
     cursor: pointer;
 }
 
@@ -49,13 +60,13 @@
     align-items: center;
     padding: 10px 15px;
     text-decoration: none;
-    color: #fff;
+    color: inherit;
     font-size: 13px;
-    transition: background 0.2s;
+    transition: background var(--transition);
 }
 
 .sidebar nav ul li a:hover {
-    background: rgba(0, 0, 0, 0.1);
+    background: var(--bg);
 }
 
 .menu-icon {
@@ -68,3 +79,4 @@
 .menu-text {
     white-space: nowrap;
 }
+

--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -3,9 +3,9 @@ import "./Sidebar.css";
 import { NavLink } from "react-router-dom";
 import { FiMenu, FiBarChart2, FiCheckSquare, FiGrid, FiSend } from "react-icons/fi";
 
-export default function Sidebar({ isOpen, onToggle }) {
+export default function Sidebar({ isOpen, onToggle, position = "left" }) {
     return (
-        <aside className={`sidebar ${isOpen ? "expanded" : "collapsed"}`}>
+        <aside className={`sidebar ${position} ${isOpen ? "expanded" : ""}`}>
             <div className="sidebar-content">
 
                 {/* Верхня панель з кнопкою */}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -33,7 +33,7 @@
     /* заголовки */
     --transition: 160ms ease;
 
-    --sidebar-width: 260px;
+    --sidebar-width: 300px;
     --sidebar-collapsed: 60px;
     --header-height: 56px;
 }


### PR DESCRIPTION
## Summary
- implement push-based layout with left and right sidebars
- add edge handles and localStorage-backed state with custom events

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*

------
https://chatgpt.com/codex/tasks/task_e_689a1d0c37d083329705cc416ccba4ba