### PR TITLE
feat: add dual sidebar layout with handles

### DIFF
--- a/src/components/layout/Layout.css
+++ b/src/components/layout/Layout.css
@@ -1,19 +1,27 @@
 .layout {
-    display: grid;
-    grid-template-columns: var(--sidebar-width) 1fr var(--right-sidebar-width);
-    height: 100vh;
+    --left-open: 0;
+    --right-open: 0;
     background: var(--bg);
+    min-height: 100vh;
+    overflow-x: hidden;
+    position: relative;
 }
 
-.layout.collapsed-sidebar {
-    grid-template-columns: var(--sidebar-collapsed) 1fr var(--right-sidebar-width);
+.layout.left-open {
+    --left-open: 1;
+}
+
+.layout.right-open {
+    --right-open: 1;
 }
 
 .layout-column {
     display: flex;
     flex-direction: column;
-    height: 100vh;
-    overflow: hidden;
+    min-height: 100vh;
+    margin-left: calc(var(--left-open) * var(--sidebar-width));
+    margin-right: calc(var(--right-open) * var(--right-sidebar-width));
+    transition: margin var(--transition);
 }
 
 .layout-content {
@@ -21,6 +29,34 @@
     min-height: 0;
     overflow-y: auto;
     padding: 20px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+}
+
+.sidebar-handle {
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 80px;
+    background: var(--surface);
+    box-shadow: var(--shadow);
+    border: none;
+    cursor: pointer;
+    z-index: 110;
+    transition: background var(--transition);
+}
+
+.sidebar-handle:hover {
     background: var(--bg);
 }
 
+.left-handle {
+    left: 0;
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.right-handle {
+    right: 0;
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+}

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,17 +1,67 @@
-import React, { useState } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import Header from "./Header/Header";
 import Sidebar, { RightSidebar } from "./Sidebar/Sidebar";
 import Footer from "./Footer/Footer";
 import "./Layout.css";
 
+const LEFT_KEY = "layout:left";
+const RIGHT_KEY = "layout:right";
+
 export default function Layout({ children }) {
-    const [menuOpen, setMenuOpen] = useState(false);
+    const [leftOpen, setLeftOpen] = useState(false);
+    const [rightOpen, setRightOpen] = useState(false);
+
+    const toggleLeft = useCallback(() => {
+        setLeftOpen((prev) => {
+            const next = !prev;
+            localStorage.setItem(LEFT_KEY, next ? "1" : "0");
+            if (next) {
+                setRightOpen(false);
+                localStorage.setItem(RIGHT_KEY, "0");
+            }
+            return next;
+        });
+    }, []);
+
+    const toggleRight = useCallback(() => {
+        setRightOpen((prev) => {
+            const next = !prev;
+            localStorage.setItem(RIGHT_KEY, next ? "1" : "0");
+            if (next) {
+                setLeftOpen(false);
+                localStorage.setItem(LEFT_KEY, "0");
+            }
+            return next;
+        });
+    }, []);
+
+    useEffect(() => {
+        const left = localStorage.getItem(LEFT_KEY) === "1";
+        const right = localStorage.getItem(RIGHT_KEY) === "1";
+        if (left) {
+            setLeftOpen(true);
+            setRightOpen(false);
+        } else if (right) {
+            setRightOpen(true);
+        }
+    }, []);
+
+    useEffect(() => {
+        const onLeft = () => toggleLeft();
+        const onRight = () => toggleRight();
+        window.addEventListener("ui:toggleLeftSidebar", onLeft);
+        window.addEventListener("ui:toggleRightSidebar", onRight);
+        return () => {
+            window.removeEventListener("ui:toggleLeftSidebar", onLeft);
+            window.removeEventListener("ui:toggleRightSidebar", onRight);
+        };
+    }, [toggleLeft, toggleRight]);
 
     return (
-        <div className={`layout ${menuOpen ? "" : "collapsed-sidebar"}`}>
+        <div className={`layout ${leftOpen ? "left-open" : ""} ${rightOpen ? "right-open" : ""}`}>
             <Sidebar
-                isOpen={menuOpen}
-                onToggle={() => setMenuOpen(!menuOpen)}
+                isOpen={leftOpen}
+                onToggle={toggleLeft}
                 resultsCount={3}
                 telegramCount={2}
             />
@@ -21,6 +71,16 @@ export default function Layout({ children }) {
                 <Footer />
             </div>
             <RightSidebar />
+            <button
+                className="sidebar-handle left-handle"
+                aria-label="Toggle left sidebar"
+                onClick={toggleLeft}
+            />
+            <button
+                className="sidebar-handle right-handle"
+                aria-label="Toggle right sidebar"
+                onClick={toggleRight}
+            />
         </div>
     );
 }

--- a/src/components/layout/Sidebar/Sidebar.css
+++ b/src/components/layout/Sidebar/Sidebar.css
@@ -2,18 +2,26 @@
     background: var(--primary);
     color: #fff;
     height: 100%;
-    transition: width var(--transition);
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: var(--sidebar-width);
+    transform: translateX(-100%);
+    transition: transform var(--transition);
+    z-index: 100;
 }
 
-.sidebar.collapsed {
-    width: var(--sidebar-collapsed);
-}
-
+.sidebar.collapsed,
 .sidebar.expanded {
     width: var(--sidebar-width);
+}
+
+.layout.left-open .sidebar {
+    transform: translateX(0);
 }
 
 .sidebar-content {
@@ -130,6 +138,17 @@
     display: flex;
     flex-direction: column;
     height: 100%;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    transform: translateX(100%);
+    transition: transform var(--transition);
+    z-index: 100;
+}
+
+.layout.right-open .right-sidebar {
+    transform: translateX(0);
 }
 
 .right-sidebar-content {

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: var(--bg);
+  color: var(--text);
 }
 
 code {


### PR DESCRIPTION
## Summary
- implement layout with left/right sidebars that push content and remember state
- add fixed handles and custom event listeners for sidebar toggling
- refine global and layout styling with surface backgrounds and shadows

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*

------
https://chatgpt.com/codex/tasks/task_e_689a2c786d9083328d174bbc02fa7347