### PR TITLE
feat: add base components for results page

### DIFF
--- a/src/modules/results/components/ResultDetails.css
+++ b/src/modules/results/components/ResultDetails.css
@@ -1,0 +1,34 @@
+@import "../../../styles/variables.css";
+
+.result-details{
+  display:grid; grid-template-columns: 1fr 1fr; gap:16px;
+  padding: 12px 12px 16px 40px; background: #fff; border-bottom:1px solid var(--border);
+}
+.rd-col{ display:grid; gap:16px; }
+.rd-block{ background:#fff; border:1px solid var(--border); border-radius: var(--radius); padding:12px; }
+.rd-block h4{ margin:0 0 10px; color: var(--navy); }
+
+.rd-line{ display:flex; gap:8px; font-size: var(--fz-base); }
+.rd-line .k{ color: var(--text-muted); min-width:120px; }
+.rd-desc{ margin-top:8px; color: var(--text); }
+
+.rd-actions{ margin-top:12px; display:flex; gap:8px; }
+
+.rd-sublist{ display:grid; gap:8px; }
+.rd-subitem{ display:flex; align-items:center; gap:8px; }
+.rd-subitem .title{ color:var(--navy); text-decoration:none; }
+.rd-subitem .who{ font-size: var(--fz-sm); color: var(--text-muted); }
+
+.rd-tasks{ display:grid; gap:8px; }
+.rd-task{
+  display:flex; align-items:center; gap:10px; padding:8px; border:1px solid var(--border);
+  border-radius: var(--radius-sm); text-decoration:none; color: var(--text);
+}
+.rd-task .t-title{ flex:1; }
+.rd-task .t-date{ font-size: var(--fz-sm); color: var(--text-muted); }
+
+.rd-comments{ display:grid; gap:10px; }
+.rd-comment .c-head{ font-size: var(--fz-sm); color: var(--text-muted); }
+.rd-comment .c-text{ margin-top:4px; }
+
+.rd-add-comment{ margin-top:8px; display:flex; gap:8px; }

--- a/src/modules/results/components/ResultDetails.jsx
+++ b/src/modules/results/components/ResultDetails.jsx
@@ -1,0 +1,92 @@
+import React from "react";
+import "./ResultDetails.css";
+
+/**
+ * Пропси:
+ * - result: {
+ *    id, description, points, status, urgent, ownerName, assigneeName,
+ *    subtasks?: Array<subResult>, // підрезультати
+ *    tasks?: Array<{id, title, date, status}>,
+ *    comments?: Array<{id, author, text, date}>
+ *  }
+ * - onAddSubresult(parentId)
+ * - onCreateTemplate(id)
+ * - onCreateTask(id)
+ */
+export default function ResultDetails({ result, onAddSubresult, onCreateTemplate, onCreateTask }) {
+  return (
+    <div className="result-details">
+      <div className="rd-col">
+        <div className="rd-block">
+          <h4>Деталі</h4>
+          <div className="rd-line"><span className="k">Постановник:</span><span className="v">{result.ownerName || "—"}</span></div>
+          <div className="rd-line"><span className="k">Відповідальний:</span><span className="v">{result.assigneeName || "—"}</span></div>
+          <div className="rd-line"><span className="k">Статус:</span><span className="v">{humanStatus(result.status)}</span></div>
+          <div className="rd-line"><span className="k">Терміновість:</span><span className="v">{result.urgent ? "Так" : "Ні"}</span></div>
+          {typeof result.points === "number" && (
+            <div className="rd-line"><span className="k">Бали:</span><span className="v">+{result.points}</span></div>
+          )}
+          {result.description && (
+            <div className="rd-desc">{result.description}</div>
+          )}
+          <div className="rd-actions">
+            <button className="btn ghost" onClick={() => onCreateTemplate && onCreateTemplate(result.id)}>Ств. шаблон</button>
+            <button className="btn" onClick={() => onCreateTask && onCreateTask(result.id)}>Ств. задачу</button>
+          </div>
+        </div>
+
+        <div className="rd-block">
+          <h4>Підрезультати</h4>
+          <div className="rd-sublist">
+            {(result.subtasks || []).map(sr => (
+              <div className="rd-subitem" key={sr.id}>
+                <a href={`/results/${sr.id}`} className="title">{sr.title}</a>
+                <span className="who">{sr.assigneeName || "—"}</span>
+              </div>
+            ))}
+          </div>
+          <button className="btn ghost" onClick={() => onAddSubresult && onAddSubresult(result.id)}>Додати підрезультат</button>
+        </div>
+      </div>
+
+      <div className="rd-col">
+        <div className="rd-block">
+          <h4>Пов’язані задачі</h4>
+          <div className="rd-tasks">
+            {(result.tasks || []).map(t => (
+              <a key={t.id} href={`/tasks/${t.id}`} className="rd-task">
+                <span className="t-title">{t.title}</span>
+                <span className="t-date">{t.date || ""}</span>
+                <span className={`badge ${t.status === "done" ? "status-done" : "neutral"}`}>{t.status === "done" ? "виконано" : "активна"}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+
+        <div className="rd-block">
+          <h4>Коментарі</h4>
+          <div className="rd-comments">
+            {(result.comments || []).map(c => (
+              <div key={c.id} className="rd-comment">
+                <div className="c-head"><b>{c.author}</b> <span className="c-date">{c.date}</span></div>
+                <div className="c-text">{c.text}</div>
+              </div>
+            ))}
+          </div>
+          <form className="rd-add-comment" onSubmit={(e)=>e.preventDefault()}>
+            <input type="text" className="input" placeholder="Додати коментар…" />
+            <button className="btn">Надіслати</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function humanStatus(s){
+  return s === "new" ? "Новий"
+    : s === "in_progress" ? "В процесі"
+    : s === "done" ? "Виконано"
+    : s === "postponed" ? "Відкладено"
+    : "—";
+}

--- a/src/modules/results/components/ResultRow.css
+++ b/src/modules/results/components/ResultRow.css
@@ -1,0 +1,32 @@
+@import "../../../styles/variables.css";
+
+.result-row{
+  display:grid; grid-template-columns: 28px 1.4fr 1fr auto; gap:12px;
+  align-items:center; padding:12px; border-bottom:1px solid var(--border);
+  background:#fff;
+}
+.result-row:hover{ box-shadow: var(--shadow); }
+
+.result-row .caret{
+  border:1px solid var(--border); background:#fff; border-radius:8px; width:28px; height:28px; cursor:pointer;
+}
+.result-row .title{
+  font-weight:600; color:var(--navy); text-decoration:none; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+}
+.result-row .meta{
+  display:flex; align-items:center; gap:8px; flex-wrap:wrap; font-size: var(--fz-sm); color: var(--text-muted);
+}
+.result-row .meta .k{ opacity:.7; }
+.result-row .meta .v{ color:var(--text); }
+
+.result-row .expected{
+  color:var(--text-muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+}
+
+.result-row .actions{ display:flex; gap:8px; flex-wrap:wrap; justify-self:end; }
+
+/* статусні бейджі */
+.badge.status-new{ border-color: var(--text-muted); color: var(--text-muted); }
+.badge.status-progress{ border-color: var(--blue); color: var(--blue); }
+.badge.status-done{ border-color: #10B981; color:#065F46; }
+.badge.status-postponed{ border-color: var(--rush); color: var(--rush-dark); }

--- a/src/modules/results/components/ResultRow.jsx
+++ b/src/modules/results/components/ResultRow.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import "./ResultRow.css";
+
+/**
+ * result: {
+ *  id, title, deadline, expected, dailyTasksCount,
+ *  urgent: boolean, status: 'new'|'in_progress'|'done'|'postponed',
+ *  ownerName
+ * }
+ * expanded: boolean
+ * onToggleExpand(id)
+ * onCreateTemplate(id)
+ * onCreateTask(id)
+ * onViewTasks(id)
+ * onEdit(id)
+ * onArchive(id)
+ * onDelete(id)  // має перевіряти права вище
+ * onMarkDone(id) // підтвердження робити вище
+ */
+export default function ResultRow({
+  result, expanded,
+  onToggleExpand, onCreateTemplate, onCreateTask, onViewTasks, onEdit, onArchive, onDelete, onMarkDone
+}) {
+  const statusClass = mapStatus(result.status);
+  return (
+    <div className={`result-row ${expanded ? "expanded" : ""}`}>
+      <button className="caret" aria-label="Розгорнути" onClick={() => onToggleExpand && onToggleExpand(result.id)}>
+        {expanded ? "▾" : "▸"}
+      </button>
+
+      <a className="title" href={`/results/${result.id}`} title={result.title}>{result.title}</a>
+
+      <div className="meta">
+        {result.deadline && <span className="k">До</span>}
+        {result.deadline && <span className="v">{result.deadline}</span>}
+        <span className={`badge ${statusClass}`}>{humanStatus(result.status)}</span>
+        {result.urgent && <span className="badge critical">Терміново</span>}
+        <span className="badge neutral">Щоденних: {result.dailyTasksCount ?? 0}</span>
+      </div>
+
+      <div className="expected" title={result.expected || ""}>
+        {result.expected || "—"}
+      </div>
+
+      <div className="actions">
+        <button className="btn ghost" onClick={() => onCreateTemplate && onCreateTemplate(result.id)}>Ств. шаблон</button>
+        <button className="btn" onClick={() => onCreateTask && onCreateTask(result.id)}>Ств. задачу</button>
+        <button className="btn ghost" onClick={() => onViewTasks && onViewTasks(result.id)}>Задачі</button>
+        <button className="btn ghost" onClick={() => onEdit && onEdit(result.id)}>Редагувати</button>
+        <button className="btn ghost" onClick={() => onArchive && onArchive(result.id)}>Архівувати</button>
+        <button className="btn ghost" onClick={() => onDelete && onDelete(result.id)}>Видалити</button>
+        <button className="btn primary" onClick={() => onMarkDone && onMarkDone(result.id)}>Позначити виконаним</button>
+      </div>
+    </div>
+  );
+}
+
+function mapStatus(s){
+  return s === "new" ? "status-new"
+    : s === "in_progress" ? "status-progress"
+    : s === "done" ? "status-done"
+    : s === "postponed" ? "status-postponed"
+    : "neutral";
+}
+function humanStatus(s){
+  return s === "new" ? "Новий"
+    : s === "in_progress" ? "В процесі"
+    : s === "done" ? "Виконано"
+    : s === "postponed" ? "Відкладено"
+    : "—";
+}

--- a/src/modules/results/components/ResultsEmpty.css
+++ b/src/modules/results/components/ResultsEmpty.css
@@ -1,0 +1,10 @@
+@import "../../../styles/variables.css";
+
+.results-empty{
+  padding:16px;
+  text-align:center;
+}
+
+.results-empty p{
+  color: var(--text-muted);
+}

--- a/src/modules/results/components/ResultsEmpty.jsx
+++ b/src/modules/results/components/ResultsEmpty.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import "./ResultsEmpty.css";
+
+export default function ResultsEmpty({ onCreate }) {
+  return (
+    <div className="results-empty card">
+      <h3>Результатів не знайдено</h3>
+      <p>Спробуйте змінити фільтри або додайте перший результат.</p>
+      <button className="btn primary" onClick={onCreate}>Додати результат</button>
+    </div>
+  );
+}

--- a/src/modules/results/components/ResultsFilters.css
+++ b/src/modules/results/components/ResultsFilters.css
@@ -1,0 +1,32 @@
+@import "../../../styles/variables.css";
+
+.results-filters{
+  padding: 12px;
+}
+
+.rf-row{
+  display:flex; align-items:center; gap:12px; flex-wrap:wrap;
+}
+
+.rf-search{
+  display:flex; align-items:center; gap:10px;
+  border:1px solid var(--border); border-radius: var(--radius-sm);
+  padding: 6px 10px; background:#fff; min-width: 320px; flex:1;
+}
+.rf-search .ico{ width:18px; height:18px; color: var(--text-muted); }
+.rf-search input{
+  width:100%; border:none; outline:none; background:transparent;
+  font-size: var(--fz-base); color: var(--text);
+}
+
+.rf-group{ display:flex; gap:10px; flex-wrap:wrap; }
+.rf-field{
+  display:flex; flex-direction:column; gap:6px;
+  font-size: var(--fz-sm); color: var(--text-muted);
+}
+.rf-field select{
+  border:1px solid var(--border); border-radius: var(--radius-sm);
+  background:#fff; padding:8px 10px; min-width:160px;
+}
+
+.rf-actions{ margin-left:auto; display:flex; gap:8px; }

--- a/src/modules/results/components/ResultsFilters.jsx
+++ b/src/modules/results/components/ResultsFilters.jsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from "react";
+import "./ResultsFilters.css";
+
+/**
+ * Пропси:
+ * - value: { q, status, hasTemplates, hasActiveTasks, view }  // view: 'list' | 'owner'
+ * - onChange(next)
+ * - onReset()
+ */
+export default function ResultsFilters({ value, onChange, onReset }) {
+  const [local, setLocal] = useState(value || { q: "", status: "all", hasTemplates: "any", hasActiveTasks: "any", view: "list" });
+
+  useEffect(() => setLocal(value), [value]);
+
+  const change = (patch) => {
+    const next = { ...local, ...patch };
+    setLocal(next);
+    onChange && onChange(next);
+  };
+
+  return (
+    <div className="results-filters card">
+      <div className="rf-row">
+        <label className="rf-search">
+          <svg viewBox="0 0 24 24" aria-hidden="true" className="ico">
+            <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" fill="none" />
+            <line x1="21" y1="21" x2="16.5" y2="16.5" stroke="currentColor" strokeWidth="2" />
+          </svg>
+          <input
+            type="search"
+            placeholder="Пошук по всіх полях…"
+            value={local.q}
+            onChange={(e) => change({ q: e.target.value })}
+          />
+        </label>
+
+        <div className="rf-group">
+          <label className="rf-field">
+            <span>Статус</span>
+            <select
+              value={local.status}
+              onChange={(e) => change({ status: e.target.value })}
+            >
+              <option value="all">Усі</option>
+              <option value="new">Новий</option>
+              <option value="in_progress">В процесі</option>
+              <option value="done">Виконано</option>
+              <option value="postponed">Відкладено</option>
+            </select>
+          </label>
+
+          <label className="rf-field">
+            <span>Шаблони</span>
+            <select
+              value={local.hasTemplates}
+              onChange={(e) => change({ hasTemplates: e.target.value })}
+            >
+              <option value="any">Неважливо</option>
+              <option value="yes">Є</option>
+              <option value="no">Немає</option>
+            </select>
+          </label>
+
+          <label className="rf-field">
+            <span>Активні задачі</span>
+            <select
+              value={local.hasActiveTasks}
+              onChange={(e) => change({ hasActiveTasks: e.target.value })}
+            >
+              <option value="any">Неважливо</option>
+              <option value="yes">Є активність</option>
+              <option value="no">Нема активності</option>
+            </select>
+          </label>
+
+          <label className="rf-field">
+            <span>Подання</span>
+            <select
+              value={local.view}
+              onChange={(e) => change({ view: e.target.value })}
+            >
+              <option value="list">Список</option>
+              <option value="owner">Групувати за постановником</option>
+            </select>
+          </label>
+        </div>
+
+        <div className="rf-actions">
+          <button className="btn ghost" onClick={() => onReset && onReset()}>Скинути фільтри</button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ResultsFilters` component for search and filtering
- add collapsed `ResultRow` and expanded `ResultDetails` views
- add `ResultsEmpty` placeholder state

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*


------
https://chatgpt.com/codex/tasks/task_e_689a2b6275a48332a7dbc876893bfdc2