### PR TITLE
feat: add templates module components skeleton

### DIFF
--- a/src/modules/templates/components/TemplateDetails.css
+++ b/src/modules/templates/components/TemplateDetails.css
@@ -1,0 +1,32 @@
+@import "../../../styles/variables.css";
+
+.tpl-details{
+  display:grid; grid-template-columns: 1fr 1fr; gap:16px;
+  padding: 12px 12px 16px 40px; background:#fff; border-bottom:1px solid var(--border);
+}
+.td-col{ display:grid; gap:16px; }
+.td-block{ background:#fff; border:1px solid var(--border); border-radius: var(--radius); padding:12px; }
+.td-block h4{ margin:0 0 10px; color: var(--navy); }
+
+.td-line{ display:flex; align-items:center; gap:10px; margin-bottom:10px; }
+.td-line .k{ color: var(--text-muted); min-width:140px; }
+.td-row{ display:flex; align-items:center; gap:10px; }
+.link{ color: var(--blue); text-decoration:none; }
+
+.td-grid{ display:grid; grid-template-columns: repeat(2, 1fr); gap:10px; }
+
+.td-actions{ margin-top:12px; display:flex; gap:8px; }
+
+.td-comments{ display:grid; gap:10px; }
+.td-comment .c-head{ font-size: var(--fz-sm); color: var(--text-muted); }
+.td-comment .c-text{ margin-top:4px; }
+
+.td-add-comment{ margin-top:8px; display:flex; gap:8px; }
+
+.td-usage{ display:grid; gap:8px; }
+.td-usage-item{
+  display:flex; align-items:center; gap:10px; padding:8px; border:1px solid var(--border);
+  border-radius: var(--radius-sm); text-decoration:none; color: var(--text);
+}
+.td-usage-item .t-title{ flex:1; }
+.td-usage-item .t-date{ font-size: var(--fz-sm); color: var(--text-muted); }

--- a/src/modules/templates/components/TemplateDetails.jsx
+++ b/src/modules/templates/components/TemplateDetails.jsx
@@ -1,0 +1,139 @@
+import React from "react";
+import "./TemplateDetails.css";
+
+/**
+ * props:
+ * - template: {
+ *    id, title, description, plannedTime, priority, scheduleHuman,
+ *    defaultAssigneeName, result: { id, title } | null,
+ *    usage?: Array<{ id, taskId, taskTitle, date }>,
+ *    comments?: Array<{ id, author, text, date }>
+ *  }
+ * - onInlineUpdate(id, patch) // {field: value}
+ * - onCreateTask(id)
+ * - onLinkResult(id) / onUnlinkResult(id)
+ * - onDuplicate(id)
+ */
+export default function TemplateDetails({
+  template, onInlineUpdate, onCreateTask, onLinkResult, onUnlinkResult, onDuplicate
+}) {
+  return (
+    <div className="tpl-details">
+      <div className="td-col">
+        <div className="td-block">
+          <h4>Опис та параметри</h4>
+
+          <label className="td-line">
+            <span className="k">Назва</span>
+            <input
+              className="input"
+              defaultValue={template.title}
+              onBlur={(e)=>onInlineUpdate && onInlineUpdate(template.id, { title: e.target.value })}
+            />
+          </label>
+
+          <label className="td-line">
+            <span className="k">Опис</span>
+            <textarea
+              className="input"
+              rows={3}
+              defaultValue={template.description || ""}
+              onBlur={(e)=>onInlineUpdate && onInlineUpdate(template.id, { description: e.target.value })}
+            />
+          </label>
+
+          <div className="td-grid">
+            <label className="td-line">
+              <span className="k">План. час</span>
+              <input
+                className="input"
+                defaultValue={template.plannedTime || "00:00"}
+                onBlur={(e)=>onInlineUpdate && onInlineUpdate(template.id, { plannedTime: e.target.value })}
+              />
+            </label>
+
+            <label className="td-line">
+              <span className="k">Пріоритет</span>
+              <select
+                className="input"
+                defaultValue={template.priority || "neutral"}
+                onChange={(e)=>onInlineUpdate && onInlineUpdate(template.id, { priority: e.target.value })}
+              >
+                <option value="critical">Важл.+термін.</option>
+                <option value="important">Важлива</option>
+                <option value="rush">Термінова</option>
+                <option value="neutral">Звичайна</option>
+              </select>
+            </label>
+
+            <label className="td-line">
+              <span className="k">Періодичність</span>
+              <input
+                className="input"
+                defaultValue={template.scheduleHuman || ""}
+                onBlur={(e)=>onInlineUpdate && onInlineUpdate(template.id, { scheduleHuman: e.target.value })}
+                title="Внутрішній формат збережіть у моделі; тут редагується читабельний підпис"
+              />
+            </label>
+
+            <label className="td-line">
+              <span className="k">Виконавець (деф.)</span>
+              <input
+                className="input"
+                defaultValue={template.defaultAssigneeName || ""}
+                onBlur={(e)=>onInlineUpdate && onInlineUpdate(template.id, { defaultAssigneeName: e.target.value })}
+              />
+            </label>
+          </div>
+
+          <div className="td-line">
+            <span className="k">Результат</span>
+            {template.result ? (
+              <div className="td-row">
+                <a className="link" href={`/results/${template.result.id}`}>{template.result.title}</a>
+                <button className="btn ghost" onClick={()=>onUnlinkResult && onUnlinkResult(template.id)}>Відв’язати</button>
+              </div>
+            ) : (
+              <button className="btn ghost" onClick={()=>onLinkResult && onLinkResult(template.id)}>Прив’язати</button>
+            )}
+          </div>
+
+          <div className="td-actions">
+            <button className="btn" onClick={()=>onCreateTask && onCreateTask(template.id)}>Створити задачу</button>
+            <button className="btn ghost" onClick={()=>onDuplicate && onDuplicate(template.id)}>Дублювати</button>
+          </div>
+        </div>
+
+        <div className="td-block">
+          <h4>Коментарі</h4>
+          <div className="td-comments">
+            {(template.comments || []).map(c=>(
+              <div key={c.id} className="td-comment">
+                <div className="c-head"><b>{c.author}</b> <span className="c-date">{c.date}</span></div>
+                <div className="c-text">{c.text}</div>
+              </div>
+            ))}
+          </div>
+          <form className="td-add-comment" onSubmit={(e)=>e.preventDefault()}>
+            <input type="text" className="input" placeholder="Додати коментар…" />
+            <button className="btn">Надіслати</button>
+          </form>
+        </div>
+      </div>
+
+      <div className="td-col">
+        <div className="td-block">
+          <h4>Історія використання</h4>
+          <div className="td-usage">
+            {(template.usage || []).map(u=>(
+              <a key={u.id} className="td-usage-item" href={`/tasks/${u.taskId}`}>
+                <span className="t-title">{u.taskTitle}</span>
+                <span className="t-date">{u.date}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/templates/components/TemplateRow.css
+++ b/src/modules/templates/components/TemplateRow.css
@@ -1,0 +1,27 @@
+@import "../../../styles/variables.css";
+
+.tpl-row{
+  display:grid; grid-template-columns: 28px 1.2fr 1fr auto;
+  gap:12px; align-items:center; padding:12px;
+  border-bottom:1px solid var(--border); background:#fff;
+}
+.tpl-row:hover{ box-shadow: var(--shadow); }
+
+.tpl-row .caret{
+  border:1px solid var(--border); background:#fff; border-radius:8px;
+  width:28px; height:28px; cursor:pointer;
+}
+
+.tpl-row .title{
+  font-weight:600; color:var(--navy); text-decoration:none;
+  overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+}
+
+.tpl-row .meta{
+  display:flex; align-items:center; gap:8px; flex-wrap:wrap;
+  font-size: var(--fz-sm);
+}
+.tpl-row .link{ color: var(--blue); text-decoration:none; }
+.tpl-row .muted{ color: var(--text-muted); }
+
+.tpl-row .actions{ display:flex; gap:8px; flex-wrap:wrap; justify-self:end; }

--- a/src/modules/templates/components/TemplateRow.jsx
+++ b/src/modules/templates/components/TemplateRow.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import "./TemplateRow.css";
+
+/**
+ * template: {
+ *  id, title, plannedTime, priority, defaultAssigneeName,
+ *  result: { id, title } | null,
+ *  scheduleHuman // читабельна періодичність (напр. "щотижня у понеділок")
+ * }
+ * onExpand(id)
+ * expanded: boolean
+ * onCreateTask(id)
+ * onEdit(id)
+ * onArchive(id)
+ * onDelete(id) // тільки власник
+ */
+export default function TemplateRow({
+  template, expanded,
+  onExpand, onCreateTask, onEdit, onArchive, onDelete
+}) {
+  return (
+    <div className={`tpl-row ${expanded ? "expanded" : ""}`}>
+      <button className="caret" aria-label="Розгорнути" onClick={() => onExpand && onExpand(template.id)}>
+        {expanded ? "▾" : "▸"}
+      </button>
+
+      <a className="title" href={`/templates/${template.id}`} title={template.title}>{template.title}</a>
+
+      <div className="meta">
+        {template.result ? (
+          <a className="link" href={`/results/${template.result.id}`}>{template.result.title}</a>
+        ) : <span className="muted">Без результату</span>}
+        <span className={`badge ${mapPriority(template.priority)}`}>{humanPriority(template.priority)}</span>
+        <span className="badge neutral">{template.plannedTime || "00:00"}</span>
+        {template.scheduleHuman && <span className="muted">{template.scheduleHuman}</span>}
+        <span className="muted">Виконавець: {template.defaultAssigneeName || "—"}</span>
+      </div>
+
+      <div className="actions">
+        <button className="btn" onClick={() => onCreateTask && onCreateTask(template.id)}>Створити задачу</button>
+        <button className="btn ghost" onClick={() => onEdit && onEdit(template.id)}>Редагувати</button>
+        <button className="btn ghost" onClick={() => onArchive && onArchive(template.id)}>Архівувати</button>
+        <button className="btn ghost" onClick={() => onDelete && onDelete(template.id)}>Видалити</button>
+      </div>
+    </div>
+  );
+}
+
+function mapPriority(p){
+  return p === "critical" ? "critical"
+    : p === "important" ? "important"
+    : p === "rush" ? "rush"
+    : "neutral";
+}
+function humanPriority(p){
+  return p === "critical" ? "важл.+термін."
+    : p === "important" ? "важлива"
+    : p === "rush" ? "термінова"
+    : "звичайна";
+}

--- a/src/modules/templates/components/TemplatesEmpty.jsx
+++ b/src/modules/templates/components/TemplatesEmpty.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function TemplatesEmpty({ onCreate }) {
+  return (
+    <div className="card" style={{ padding: 16, textAlign: "center" }}>
+      <h3>Шаблонів не знайдено</h3>
+      <p style={{ color: "var(--text-muted)" }}>Створіть перший шаблон, щоб швидше планувати повторювані задачі.</p>
+      <button className="btn primary" onClick={onCreate}>Додати шаблон</button>
+    </div>
+  );
+}

--- a/src/modules/templates/components/TemplatesFilters.css
+++ b/src/modules/templates/components/TemplatesFilters.css
@@ -1,0 +1,28 @@
+@import "../../../styles/variables.css";
+
+.tpl-filters{ padding:12px; }
+
+.tf-row{ display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
+
+.tf-search{
+  display:flex; align-items:center; gap:10px;
+  border:1px solid var(--border); border-radius: var(--radius-sm);
+  padding:6px 10px; background:#fff; min-width:320px; flex:1;
+}
+.tf-search .ico{ width:18px; height:18px; color: var(--text-muted); }
+.tf-search input{
+  width:100%; border:none; outline:none; background:transparent;
+  font-size: var(--fz-base); color: var(--text);
+}
+
+.tf-group{ display:flex; gap:10px; flex-wrap:wrap; }
+.tf-field{
+  display:flex; flex-direction:column; gap:6px;
+  font-size: var(--fz-sm); color: var(--text-muted);
+}
+.tf-field select{
+  border:1px solid var(--border); border-radius: var(--radius-sm);
+  background:#fff; padding:8px 10px; min-width:160px;
+}
+
+.tf-actions{ margin-left:auto; display:flex; gap:8px; }

--- a/src/modules/templates/components/TemplatesFilters.jsx
+++ b/src/modules/templates/components/TemplatesFilters.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from "react";
+import "./TemplatesFilters.css";
+
+/**
+ * props:
+ *  - value: { q, resultId, priority, defaultAssigneeId, view } // view: 'list'|'by_result'|'by_assignee'
+ *  - onChange(next)
+ *  - onReset()
+ */
+export default function TemplatesFilters({ value, onChange, onReset }) {
+  const [local, setLocal] = useState(
+    value || { q: "", resultId: "any", priority: "any", defaultAssigneeId: "any", view: "list" }
+  );
+
+  useEffect(() => setLocal(value), [value]);
+
+  const change = (patch) => {
+    const next = { ...local, ...patch };
+    setLocal(next);
+    onChange && onChange(next);
+  };
+
+  return (
+    <div className="tpl-filters card">
+      <div className="tf-row">
+        <label className="tf-search" aria-label="Пошук по всіх полях">
+          <svg viewBox="0 0 24 24" className="ico" aria-hidden="true">
+            <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" fill="none" />
+            <line x1="21" y1="21" x2="16.5" y2="16.5" stroke="currentColor" strokeWidth="2" />
+          </svg>
+          <input
+            type="search"
+            placeholder="Пошук по всіх полях…"
+            value={local.q}
+            onChange={(e) => change({ q: e.target.value })}
+          />
+        </label>
+
+        <div className="tf-group">
+          <label className="tf-field">
+            <span>Результат</span>
+            <select
+              value={local.resultId}
+              onChange={(e) => change({ resultId: e.target.value })}
+            >
+              <option value="any">Будь‑який</option>
+              {/* Підставити опції з пропів/стору */}
+            </select>
+          </label>
+
+          <label className="tf-field">
+            <span>Пріоритет/тип</span>
+            <select
+              value={local.priority}
+              onChange={(e) => change({ priority: e.target.value })}
+            >
+              <option value="any">Будь‑який</option>
+              <option value="critical">Важл.+термін.</option>
+              <option value="important">Важлива</option>
+              <option value="rush">Термінова</option>
+              <option value="neutral">Звичайна</option>
+            </select>
+          </label>
+
+          <label className="tf-field">
+            <span>Виконавець (деф.)</span>
+            <select
+              value={local.defaultAssigneeId}
+              onChange={(e) => change({ defaultAssigneeId: e.target.value })}
+            >
+              <option value="any">Будь‑хто</option>
+              {/* Підставити опції з пропів/стору */}
+            </select>
+          </label>
+
+          <label className="tf-field">
+            <span>Вид</span>
+            <select
+              value={local.view}
+              onChange={(e) => change({ view: e.target.value })}
+            >
+              <option value="list">Список</option>
+              <option value="by_result">За результатом</option>
+              <option value="by_assignee">За виконавцем</option>
+            </select>
+          </label>
+        </div>
+
+        <div className="tf-actions">
+          <button className="btn ghost" onClick={() => onReset && onReset()}>Скинути фільтри</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/modules/templates/pages/TemplatesPage.css
+++ b/src/modules/templates/pages/TemplatesPage.css
@@ -1,0 +1,4 @@
+@import "../../../styles/variables.css";
+
+.templates-page{ display:flex; flex-direction:column; gap:16px; }
+.tpl-list{ display:grid; }

--- a/src/modules/templates/pages/TemplatesPage.jsx
+++ b/src/modules/templates/pages/TemplatesPage.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import Layout from "../../../components/layout/Layout";
+import TemplatesFilters from "../components/TemplatesFilters";
+import TemplateRow from "../components/TemplateRow";
+import TemplateDetails from "../components/TemplateDetails";
+import TemplatesEmpty from "../components/TemplatesEmpty";
+import "./TemplatesPage.css";
+
+export default function TemplatesPage() {
+  const [filters, setFilters] = useState({ q: "", resultId: "any", priority: "any", defaultAssigneeId: "any", view: "list" });
+  const [expandedId, setExpandedId] = useState(null);
+  const data = [];
+
+  const onReset = () => setFilters({ q: "", resultId: "any", priority: "any", defaultAssigneeId: "any", view: "list" });
+  const toggleExpand = (id) => setExpandedId(expandedId === id ? null : id);
+
+  return (
+    <Layout>
+      <div className="templates-page">
+        <h1>Шаблони</h1>
+        <TemplatesFilters value={filters} onChange={setFilters} onReset={onReset} />
+        {data.length === 0 ? (
+          <TemplatesEmpty onCreate={() => {}} />
+        ) : (
+          <div className="tpl-list">
+            {data.map((t) => (
+              <React.Fragment key={t.id}>
+                <TemplateRow
+                  template={t}
+                  expanded={expandedId === t.id}
+                  onExpand={toggleExpand}
+                  onCreateTask={() => {}}
+                  onEdit={() => {}}
+                  onArchive={() => {}}
+                  onDelete={() => {}}
+                />
+                {expandedId === t.id && (
+                  <TemplateDetails
+                    template={t}
+                    onInlineUpdate={() => {}}
+                    onCreateTask={() => {}}
+                    onLinkResult={() => {}}
+                    onUnlinkResult={() => {}}
+                    onDuplicate={() => {}}
+                  />
+                )}
+              </React.Fragment>
+            ))}
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add templates filters, row, details and empty components
- stub templates page integrating new pieces

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3bed70788332ae0917b4f13491c7