### PR TITLE
Fix templates route

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -87,7 +87,7 @@ export default function Sidebar({
                                     </li>
                                     <li>
                                         <NavLink
-                                            to="/results/templates"
+                                            to="/templates"
                                             className={({ isActive }) =>
                                                 isActive ? "active" : ""
                                             }

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 import HomePage from "../pages/HomePage";
 import DailyTasksPage from "../modules/tasks/pages/DailyTasksPage";
 import ResultsPage from "../modules/results/pages/ResultsPage";
+import TemplatesPage from "../modules/templates/pages/TemplatesPage";
 import OrgStructurePage from "../modules/orgStructure/pages/OrgStructurePage";
 import TelegramGroupPage from "../modules/telegram/pages/TelegramGroupPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
@@ -41,6 +42,14 @@ export default function AppRouter() {
                     element={
                         <RequireAuth>
                             <ResultsPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/templates"
+                    element={
+                        <RequireAuth>
+                            <TemplatesPage />
                         </RequireAuth>
                     }
                 />


### PR DESCRIPTION
## Summary
- Fix sidebar link to Templates page
- Add `/templates` route and page hook up

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689a4464168c8332aa0381d2b2ff9ac7