### PR TITLE
Fix templates route and restyle sidebar

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.css
+++ b/src/components/layout/Sidebar/Sidebar.css
@@ -1,6 +1,6 @@
 .sidebar {
-    background: var(--primary);
-    color: #fff;
+    background: var(--surface);
+    color: var(--text);
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -13,6 +13,8 @@
     transform: translateX(-100%);
     transition: transform var(--transition);
     z-index: 100;
+    border-right: 1px solid var(--border);
+    box-shadow: var(--shadow);
 }
 
 .sidebar.collapsed,
@@ -35,13 +37,14 @@
     align-items: center;
     justify-content: space-between;
     padding: 10px;
+    border-bottom: 1px solid var(--border);
 }
 
 /* Кнопка гамбургеру */
 .sidebar-toggle {
     background: none;
     border: none;
-    color: #fff;
+    color: var(--text);
     cursor: pointer;
 }
 
@@ -67,15 +70,17 @@
     text-decoration: none;
     background: none;
     border: none;
-    color: #fff;
+    color: var(--text);
     font-size: 13px;
     cursor: pointer;
-    transition: background 0.2s;
+    border-left: 4px solid transparent;
+    transition: background var(--transition),
+        border-color var(--transition);
 }
 
 .sidebar nav ul li a:hover,
 .menu-link:hover {
-    background: rgba(0, 0, 0, 0.1);
+    background: var(--bg);
 }
 
 .menu-link:focus,
@@ -86,8 +91,8 @@
 
 .sidebar nav ul li a.active,
 .sidebar nav ul li.active > .menu-link {
-    background: rgba(255, 255, 255, 0.15);
-    border-left: 4px solid var(--primary);
+    background: var(--bg);
+    border-left-color: var(--blue);
 }
 
 .menu-icon {
@@ -103,11 +108,10 @@
 
 .menu-badge {
     margin-left: auto;
-    background: #fff;
-    color: var(--primary);
-    border-radius: 12px;
-    padding: 0 6px;
-    font-size: 10px;
+    padding: 2px 6px;
+    font-size: var(--fz-sm);
+    background: var(--bg);
+    color: var(--text);
 }
 
 .submenu {

--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -62,7 +62,7 @@ export default function Sidebar({
                                 {isOpen && (
                                     <>
                                         <span className="menu-text">Результати</span>
-                                        <span className="menu-badge">{resultsCount}</span>
+                                        <span className="badge menu-badge">{resultsCount}</span>
                                         <FiChevronDown
                                             className={`submenu-arrow ${
                                                 isResultsOpen ? "open" : ""
@@ -87,7 +87,7 @@ export default function Sidebar({
                                     </li>
                                     <li>
                                         <NavLink
-                                            to="/results/templates"
+                                            to="/templates"
                                             className={({ isActive }) =>
                                                 isActive ? "active" : ""
                                             }
@@ -158,7 +158,7 @@ export default function Sidebar({
                                         <span className="menu-text">
                                             Телеграм
                                         </span>
-                                        <span className="menu-badge">
+                                        <span className="badge menu-badge">
                                             {telegramCount}
                                         </span>
                                     </>

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 import HomePage from "../pages/HomePage";
 import DailyTasksPage from "../modules/tasks/pages/DailyTasksPage";
 import ResultsPage from "../modules/results/pages/ResultsPage";
+import TemplatesPage from "../modules/templates/pages/TemplatesPage";
 import OrgStructurePage from "../modules/orgStructure/pages/OrgStructurePage";
 import TelegramGroupPage from "../modules/telegram/pages/TelegramGroupPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
@@ -41,6 +42,14 @@ export default function AppRouter() {
                     element={
                         <RequireAuth>
                             <ResultsPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/templates"
+                    element={
+                        <RequireAuth>
+                            <TemplatesPage />
                         </RequireAuth>
                     }
                 />


### PR DESCRIPTION
## Summary
- Fix sidebar link to Templates page
- Add `/templates` route and page hook up
- Restyle sidebars to use design-token colors and badge components

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689a4464168c8332aa0381d2b2ff9ac7