### PR TITLE
Add cascade completion confirmation and empty results state

### DIFF
--- a/src/modules/results/pages/ResultsPage.css
+++ b/src/modules/results/pages/ResultsPage.css
@@ -122,6 +122,15 @@
     color: #666;
 }
 
+.results-empty {
+    text-align: center;
+    padding: 24px 0;
+}
+
+.results-empty .btn-primary {
+    margin-top: 8px;
+}
+
 /* ===== Адаптив ===== */
 @media (max-width: 1100px) {
     .results-page {

--- a/src/shared/components/FiltersBar.css
+++ b/src/shared/components/FiltersBar.css
@@ -1,0 +1,15 @@
+.filters-bar {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+}
+
+.filters-bar input {
+    flex: 1 1 280px;
+    padding: 8px 10px;
+}
+
+.filters-bar select {
+    padding: 8px 10px;
+}

--- a/src/shared/components/FiltersBar.jsx
+++ b/src/shared/components/FiltersBar.jsx
@@ -1,22 +1,21 @@
 import React from "react";
+import "./FiltersBar.css";
 
 export default function FiltersBar({ q, status, onChange, onSubmit, onReset }) {
     return (
         <form
+            className="filters-bar"
             onSubmit={(e) => { e.preventDefault(); onSubmit?.(); }}
-            style={{ display: 'flex', gap: 8, marginBottom: 16, flexWrap: 'wrap' }}
         >
             <input
                 type="text"
                 placeholder="Пошук (назва/опис/очікуваний)"
                 value={q}
                 onChange={(e) => onChange?.({ q: e.target.value })}
-                style={{ flex: '1 1 280px', padding: '8px 10px' }}
             />
             <select
                 value={status}
                 onChange={(e) => onChange?.({ status: e.target.value })}
-                style={{ padding: '8px 10px' }}
             >
                 <option value="">Всі</option>
                 <option value="active">Активні</option>


### PR DESCRIPTION
## Summary
- add confirmation before marking a result as completed and update list in place
- show empty state with quick access to result creation
- move filters bar styling into dedicated CSS file

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689a6f786c6883329d787c90a56ce56c