### PR TITLE
Refactor results page to new list layout

### DIFF
--- a/src/modules/results/components/ResultRow.jsx
+++ b/src/modules/results/components/ResultRow.jsx
@@ -48,7 +48,9 @@ export default function ResultRow({
         <button className="btn ghost" onClick={() => onViewTasks && onViewTasks(result.id)}>Задачі</button>
         <button className="btn ghost" onClick={() => onEdit && onEdit(result.id)}>Редагувати</button>
         <button className="btn ghost" onClick={() => onArchive && onArchive(result.id)}>Архівувати</button>
-        <button className="btn ghost" onClick={() => onDelete && onDelete(result.id)}>Видалити</button>
+        {onDelete && (
+          <button className="btn ghost" onClick={() => onDelete(result.id)}>Видалити</button>
+        )}
         <button className="btn primary" onClick={() => onMarkDone && onMarkDone(result.id)}>Позначити виконаним</button>
       </div>
     </div>

--- a/src/modules/results/components/ResultsFilters.jsx
+++ b/src/modules/results/components/ResultsFilters.jsx
@@ -28,6 +28,7 @@ export default function ResultsFilters({ value, onChange, onReset }) {
           </svg>
           <input
             type="search"
+            className="input"
             placeholder="Пошук по всіх полях…"
             value={local.q}
             onChange={(e) => change({ q: e.target.value })}
@@ -38,6 +39,7 @@ export default function ResultsFilters({ value, onChange, onReset }) {
           <label className="rf-field">
             <span>Статус</span>
             <select
+              className="input"
               value={local.status}
               onChange={(e) => change({ status: e.target.value })}
             >
@@ -52,6 +54,7 @@ export default function ResultsFilters({ value, onChange, onReset }) {
           <label className="rf-field">
             <span>Шаблони</span>
             <select
+              className="input"
               value={local.hasTemplates}
               onChange={(e) => change({ hasTemplates: e.target.value })}
             >
@@ -64,6 +67,7 @@ export default function ResultsFilters({ value, onChange, onReset }) {
           <label className="rf-field">
             <span>Активні задачі</span>
             <select
+              className="input"
               value={local.hasActiveTasks}
               onChange={(e) => change({ hasActiveTasks: e.target.value })}
             >
@@ -76,6 +80,7 @@ export default function ResultsFilters({ value, onChange, onReset }) {
           <label className="rf-field">
             <span>Подання</span>
             <select
+              className="input"
               value={local.view}
               onChange={(e) => change({ view: e.target.value })}
             >

--- a/src/modules/results/pages/ResultsPage.css
+++ b/src/modules/results/pages/ResultsPage.css
@@ -1,172 +1,41 @@
-.results-page {
-    padding: 20px;
-    max-width: 1100px;
-    margin: 0 auto;
-    background: #fff;
+@import "../../../styles/variables.css";
+
+.results-page{
+  padding:20px;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
 }
 
-.results-page__header {
-    margin-bottom: 12px;
+.results-page__header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
 }
 
-.results-page__filters {
-    margin-bottom: 12px;
+.results-list{
+  display:grid;
+  gap:0;
 }
 
-/* ===== Create form ===== */
-.results-create-form {
-    display: grid;
-    grid-template-columns: 2fr 2fr 2fr 1fr 1fr;
-    gap: 8px;
-    margin-bottom: 16px;
+.results-group + .results-group{
+  margin-top:16px;
 }
 
-.results-create-form .btn-primary {
-    grid-column: 1 / -1;
+.group-title{
+  margin:0;
+  padding:8px 12px;
+  font-weight:600;
 }
 
-/* ===== Table ===== */
-.results-table {
-    width: 100%;
-    border-collapse: collapse;
-    border: 1px solid #eee;
-    font-size: 14px;
+.results-pagination{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:12px;
+  margin-top:16px;
 }
 
-.results-table thead tr {
-    background: #fafafa;
-}
-
-.results-table th,
-.results-table td {
-    padding: 8px 10px;
-    border: 1px solid #eee;
-    text-align: left;
-}
-
-.results-table .actions {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-}
-
-.expander {
-    margin-right: 8px;
-}
-
-/* Розгортка */
-.row-expanded td {
-    background: #fcfcff;
-}
-
-.expanded-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
-}
-
-/* Редагування */
-.row-edit td {
-    background: #fff9f2;
-}
-
-.edit-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr 140px 1fr;
-    gap: 8px;
-}
-
-.edit-actions {
-    margin-top: 10px;
-    display: flex;
-    gap: 8px;
-}
-
-/* Підрезультат */
-.subresult-form {
-    display: grid;
-    grid-template-columns: 2fr 2fr 2fr 1fr auto;
-    gap: 8px;
-}
-
-/* Кнопки — базові стилі під помаранчево-сірий стиль */
-.btn-primary {
-    background: #ff6600;
-    color: #fff;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 4px;
-    cursor: pointer;
-}
-
-.btn-secondary {
-    background: #f3f3f3;
-    color: #222;
-    border: 1px solid #ddd;
-    padding: 8px 12px;
-    border-radius: 4px;
-    cursor: pointer;
-}
-
-.btn-danger {
-    background: #ffe6e6;
-    color: #b00020;
-    border: 1px solid #ffcaca;
-    padding: 8px 12px;
-    border-radius: 4px;
-    cursor: pointer;
-}
-
-.results-loader {
-    padding: 12px 0;
-    color: #666;
-}
-
-.results-empty {
-    text-align: center;
-    padding: 24px 0;
-}
-
-.results-empty .btn-primary {
-    margin-top: 8px;
-}
-
-/* ===== Адаптив ===== */
-@media (max-width: 1100px) {
-    .results-page {
-        padding: 16px;
-    }
-}
-
-@media (max-width: 900px) {
-    .results-create-form {
-        grid-template-columns: 1fr 1fr;
-    }
-
-    .edit-grid {
-        grid-template-columns: 1fr 1fr;
-    }
-
-    .expanded-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .subresult-form {
-        grid-template-columns: 1fr 1fr;
-    }
-}
-
-@media (max-width: 600px) {
-
-    .results-create-form,
-    .edit-grid,
-    .subresult-form {
-        grid-template-columns: 1fr;
-    }
-
-    .results-table th:nth-child(4),
-    .results-table td:nth-child(4) {
-        display: none;
-        /* сховаємо колонку "Задачі" на дуже вузьких екранах */
-    }
+.results-loader{
+  padding:12px 0;
 }

--- a/src/modules/results/pages/ResultsPage.jsx
+++ b/src/modules/results/pages/ResultsPage.jsx
@@ -1,314 +1,203 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import Layout from '../../../components/layout/Layout.jsx';
 import {
-    getResults, getResult, createResult, updateResult, deleteResult, toggleResultComplete,
+  getResults,
+  getResult,
+  deleteResult,
+  toggleResultComplete,
 } from '../api/results';
-import Pagination from '../../../shared/components/Pagination';
-import FiltersBar from '../../../shared/components/FiltersBar';
+import ResultsFilters from '../components/ResultsFilters.jsx';
+import ResultRow from '../components/ResultRow.jsx';
+import ResultDetails from '../components/ResultDetails.jsx';
+import ResultsEmpty from '../components/ResultsEmpty.jsx';
 import './ResultsPage.css';
 
-const initialForm = { title: '', description: '', expected_result: '', deadline: '', parent_id: null };
+const defaultFilters = {
+  q: '',
+  status: 'all',
+  hasTemplates: 'any',
+  hasActiveTasks: 'any',
+  view: 'list',
+};
 
 export default function ResultsPage() {
-    const [list, setList] = useState([]);
-    const [pagination, setPagination] = useState({ page: 1, pageCount: 1, pageSize: 25, totalCount: 0 });
-    const [loading, setLoading] = useState(false);
-    const [createForm, setCreateForm] = useState(initialForm);
-    const [expanded, setExpanded] = useState({});
-    const [editingId, setEditingId] = useState(null);
-    const [editForm, setEditForm] = useState(initialForm);
-    const [filters, setFilters] = useState({ q: '', status: '' });
-    const createFormRef = useRef(null);
+  const [list, setList] = useState([]);
+  const [filters, setFilters] = useState(defaultFilters);
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState({ page: 1, pageCount: 1, totalCount: 0 });
+  const [loading, setLoading] = useState(false);
+  const [expanded, setExpanded] = useState(null);
 
-    const fetchPage = async (page = 1) => {
-        setLoading(true);
+  useEffect(() => {
+    fetchList();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters, page]);
+
+  const fetchList = async () => {
+    setLoading(true);
+    try {
+      const params = { page };
+      if (filters.q) params.q = filters.q;
+      if (filters.status && filters.status !== 'all') params.status = filters.status;
+      if (filters.hasTemplates && filters.hasTemplates !== 'any') params.hasTemplates = filters.hasTemplates;
+      if (filters.hasActiveTasks && filters.hasActiveTasks !== 'any') params.hasActiveTasks = filters.hasActiveTasks;
+      if (filters.view) params.view = filters.view;
+      const data = await getResults(params);
+      const items = (data.items || []).map((r) => ({
+        ...r,
+        expected: r.expected_result || r.expected,
+        dailyTasksCount: r.daily_tasks_count ?? r.tasks_total ?? 0,
+        urgent: r.is_urgent || r.urgent,
+        ownerName: r.owner_name || r.ownerName,
+        assigneeName: r.assignee_name || r.assigneeName,
+      }));
+      setList(items);
+      setPagination(data.pagination || { page, pageCount: 1, totalCount: 0 });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onFiltersChange = (next) => {
+    setFilters(next);
+    setPage(1);
+  };
+  const onFiltersReset = () => {
+    setFilters(defaultFilters);
+    setPage(1);
+  };
+
+  const toggleExpand = async (id) => {
+    const next = expanded === id ? null : id;
+    setExpanded(next);
+    if (next) {
+      const idx = list.findIndex((r) => r.id === id);
+      if (idx >= 0 && !list[idx].detailsLoaded) {
         try {
-            const data = await getResults({ page, q: filters.q || undefined, status: filters.status || undefined });
-            setList(data.items || []);
-            setPagination(data.pagination || {});
-        } finally { setLoading(false); }
-    };
-
-    useEffect(() => { fetchPage(1); /* eslint-disable-line */ }, []);
-    const refreshCurrent = () => fetchPage(pagination.page || 1);
-
-    const onFiltersSubmit = () => fetchPage(1);
-    const onFiltersReset = () => { setFilters({ q: '', status: '' }); fetchPage(1); };
-    const onFiltersChange = (patch) => setFilters((s) => ({ ...s, ...patch }));
-
-    const onCreate = async (e) => {
-        e.preventDefault();
-        if (!createForm.title.trim()) return;
-        await createResult({
-            title: createForm.title.trim(),
-            description: createForm.description || null,
-            expected_result: createForm.expected_result || null,
-            deadline: createForm.deadline || null,
-            parent_id: createForm.parent_id || null,
-        });
-        setCreateForm(initialForm);
-        if (createForm.parent_id) setExpanded((s) => ({ ...s, [createForm.parent_id]: true }));
-        refreshCurrent();
-    };
-
-    const onDelete = async (id) => {
-        if (!window.confirm('Видалити результат?')) return;
-        await deleteResult(id);
-        refreshCurrent();
-    };
-
-    const onToggle = async (r) => {
-        if (!r.is_completed) {
-            const ok = window.confirm('Позначити результат виконаним? Це каскадно закриє усі підрезультати та задачі.');
-            if (!ok) return;
+          const full = await getResult(id);
+          setList((prev) =>
+            prev.map((x) =>
+              x.id === id
+                ? {
+                    ...x,
+                    ...full,
+                    expected: full.expected_result || full.expected,
+                    dailyTasksCount: full.daily_tasks_count ?? x.dailyTasksCount,
+                    urgent: full.is_urgent || full.urgent,
+                    ownerName: full.owner_name || full.ownerName,
+                    assigneeName: full.assignee_name || full.assigneeName,
+                    detailsLoaded: true,
+                  }
+                : x
+            )
+          );
+        } catch (_) {
+          /* ignore */
         }
-        await toggleResultComplete(r.id, !r.is_completed);
-        if (!r.is_completed) {
-            setList((prev) => prev.map((x) => x.id === r.id ? { ...x, is_completed: true, tasks_done: x.tasks_total } : x));
-        } else {
-            refreshCurrent();
-        }
-    };
+      }
+    }
+  };
 
-    const openEdit = (r) => {
-        setEditingId(r.id);
-        setEditForm({
-            title: r.title || '',
-            description: r.description || '',
-            expected_result: r.expected_result || '',
-            deadline: r.deadline || '',
-            parent_id: r.parent_id || null,
-        });
-    };
-    const cancelEdit = () => { setEditingId(null); setEditForm(initialForm); };
-    const saveEdit = async () => { await updateResult(editingId, editForm); setEditingId(null); refreshCurrent(); };
+  const onDelete = async (id) => {
+    if (!window.confirm('Видалити результат?')) return;
+    await deleteResult(id);
+    fetchList();
+  };
 
-    const toggleExpand = async (id) => {
-        const next = !expanded[id];
-        setExpanded((s) => ({ ...s, [id]: next }));
-        if (next) { try { await getResult(id); } catch (_) { } }
-    };
-
-    return (
-        <Layout>
-            <div className="results-page">
-                <div className="results-page__header">
-                    <h1>Результати</h1>
-                </div>
-
-                <div className="results-page__filters">
-                    <FiltersBar
-                        q={filters.q}
-                        status={filters.status}
-                        onChange={onFiltersChange}
-                        onSubmit={onFiltersSubmit}
-                        onReset={onFiltersReset}
-                    />
-                </div>
-
-                <form ref={createFormRef} className="results-create-form" onSubmit={onCreate}>
-                    <input
-                        type="text"
-                        placeholder="Назва *"
-                        value={createForm.title}
-                        onChange={(e) => setCreateForm((s) => ({ ...s, title: e.target.value }))}
-                        required
-                    />
-                    <input
-                        type="text"
-                        placeholder="Опис"
-                        value={createForm.description}
-                        onChange={(e) => setCreateForm((s) => ({ ...s, description: e.target.value }))}
-                    />
-                    <input
-                        type="text"
-                        placeholder="Очікуваний результат"
-                        value={createForm.expected_result}
-                        onChange={(e) => setCreateForm((s) => ({ ...s, expected_result: e.target.value }))}
-                    />
-                    <input
-                        type="date"
-                        value={createForm.deadline}
-                        onChange={(e) => setCreateForm((s) => ({ ...s, deadline: e.target.value }))}
-                    />
-                    <select
-                        value={createForm.parent_id || ''}
-                        onChange={(e) => setCreateForm((s) => ({ ...s, parent_id: e.target.value ? Number(e.target.value) : null }))}
-                    >
-                        <option value="">Без батька</option>
-                        {list.map((r) => <option key={r.id} value={r.id}>{`#${r.id} ${r.title}`}</option>)}
-                    </select>
-                    <button type="submit" className="btn-primary">Додати</button>
-                </form>
-
-                {loading ? (
-                    <p className="results-loader">Завантаження...</p>
-                ) : list.length === 0 ? (
-                    <div className="results-empty">
-                        <p>Результатів не знайдено</p>
-                        <button
-                            className="btn-primary"
-                            onClick={() => createFormRef.current?.scrollIntoView({ behavior: 'smooth' })}
-                        >
-                            Додати результат
-                        </button>
-                    </div>
-                ) : (
-                    <table className="results-table">
-                        <thead>
-                            <tr>
-                                <th style={{ width: 60 }}>ID</th>
-                                <th>Назва</th>
-                                <th style={{ width: 120 }}>Дедлайн</th>
-                                <th style={{ width: 140 }}>Задачі (вик/всього)</th>
-                                <th style={{ width: 100 }}>Статус</th>
-                                <th style={{ width: 280 }}>Дії</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {list.map((r) => (
-                                <React.Fragment key={r.id}>
-                                    <tr>
-                                        <td>#{r.id}</td>
-                                        <td>
-                                            <button className="expander" onClick={() => toggleExpand(r.id)}>
-                                                {expanded[r.id] ? '▾' : '▸'}
-                                            </button>
-                                            {r.title}
-                                        </td>
-                                        <td>{r.deadline || '—'}</td>
-                                        <td>{`${r.tasks_done}/${r.tasks_total}`}</td>
-                                        <td>{r.is_completed ? '✅ Виконано' : '❌ Активний'}</td>
-                                        <td className="actions">
-                                            <button className="btn-secondary" onClick={() => onToggle(r)}>
-                                                {r.is_completed ? 'Зняти виконання' : 'Позначити виконаним'}
-                                            </button>
-                                            <button className="btn-secondary" onClick={() => openEdit(r)}>Редагувати</button>
-                                            <button className="btn-danger" onClick={() => onDelete(r.id)}>Видалити</button>
-                                        </td>
-                                    </tr>
-
-                                    {expanded[r.id] && (
-                                        <tr className="row-expanded">
-                                            <td colSpan={6}>
-                                                <div className="expanded-grid">
-                                                    <div>
-                                                        <h4>Деталі</h4>
-                                                        <div><b>Опис:</b> {r.description || '—'}</div>
-                                                        <div><b>Очікуваний результат:</b> {r.expected_result || '—'}</div>
-                                                        <div><b>Дедлайн:</b> {r.deadline || '—'}</div>
-                                                        <div><b>Підрезультатів:</b> {r.children_count}</div>
-                                                    </div>
-                                                    <div>
-                                                        <h4>Додати підрезультат</h4>
-                                                        <SubresultInlineForm parentId={r.id} onAdded={refreshCurrent} />
-                                                    </div>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    )}
-
-                                    {editingId === r.id && (
-                                        <tr className="row-edit">
-                                            <td colSpan={6}>
-                                                <h4>Редагувати результат</h4>
-                                                <div className="edit-grid">
-                                                    <input
-                                                        type="text"
-                                                        placeholder="Назва *"
-                                                        value={editForm.title}
-                                                        onChange={(e) => setEditForm((s) => ({ ...s, title: e.target.value }))}
-                                                    />
-                                                    <input
-                                                        type="text"
-                                                        placeholder="Опис"
-                                                        value={editForm.description}
-                                                        onChange={(e) => setEditForm((s) => ({ ...s, description: e.target.value }))}
-                                                    />
-                                                    <input
-                                                        type="text"
-                                                        placeholder="Очікуваний результат"
-                                                        value={editForm.expected_result}
-                                                        onChange={(e) => setEditForm((s) => ({ ...s, expected_result: e.target.value }))}
-                                                    />
-                                                    <input
-                                                        type="date"
-                                                        value={editForm.deadline || ''}
-                                                        onChange={(e) => setEditForm((s) => ({ ...s, deadline: e.target.value }))}
-                                                    />
-                                                    <select
-                                                        value={editForm.parent_id || ''}
-                                                        onChange={(e) => setEditForm((s) => ({ ...s, parent_id: e.target.value ? Number(e.target.value) : null }))}
-                                                    >
-                                                        <option value="">Без батька</option>
-                                                        {list.filter(x => x.id !== r.id).map((x) => (
-                                                            <option key={x.id} value={x.id}>{`#${x.id} ${x.title}`}</option>
-                                                        ))}
-                                                    </select>
-                                                </div>
-                                                <div className="edit-actions">
-                                                    <button className="btn-primary" onClick={saveEdit}>Зберегти</button>
-                                                    <button className="btn-secondary" onClick={cancelEdit}>Скасувати</button>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    )}
-                                </React.Fragment>
-                            ))}
-                        </tbody>
-                    </table>
-                )}
-
-                <div className="results-page__pagination">
-                    <Pagination page={pagination.page} pageCount={pagination.pageCount} onChange={(p) => fetchPage(p)} />
-                </div>
-            </div>
-        </Layout>
+  const onMarkDone = async (id) => {
+    const r = list.find((x) => x.id === id);
+    if (!r) return;
+    const ok = window.confirm(
+      'Позначити результат виконаним? Це каскадно закриє усі підрезультати та задачі.'
     );
-}
+    if (!ok) return;
+    await toggleResultComplete(id, true);
+    setList((prev) => prev.map((x) => (x.id === id ? { ...x, status: 'done' } : x)));
+  };
 
-function SubresultInlineForm({ parentId, onAdded }) {
-    const [form, setForm] = useState({ title: '', description: '', expected_result: '', deadline: '' });
-    const createSub = async (e) => {
-        e.preventDefault();
-        if (!form.title.trim()) return;
-        await createResult({
-            title: form.title.trim(),
-            description: form.description || null,
-            expected_result: form.expected_result || null,
-            deadline: form.deadline || null,
-            parent_id: parentId,
-        });
-        setForm({ title: '', description: '', expected_result: '', deadline: '' });
-        onAdded?.();
-    };
-    return (
-        <form className="subresult-form" onSubmit={createSub}>
-            <input
-                type="text"
-                placeholder="Назва *"
-                value={form.title}
-                onChange={(e) => setForm((s) => ({ ...s, title: e.target.value }))}
-                required
-            />
-            <input
-                type="text"
-                placeholder="Опис"
-                value={form.description}
-                onChange={(e) => setForm((s) => ({ ...s, description: e.target.value }))}
-            />
-            <input
-                type="text"
-                placeholder="Очікуваний результат"
-                value={form.expected_result}
-                onChange={(e) => setForm((s) => ({ ...s, expected_result: e.target.value }))}
-            />
-            <input
-                type="date"
-                value={form.deadline}
-                onChange={(e) => setForm((s) => ({ ...s, deadline: e.target.value }))}
-            />
-            <button type="submit" className="btn-secondary">Додати</button>
-        </form>
-    );
+  const rows = (items) =>
+    items.map((r) => (
+      <React.Fragment key={r.id}>
+        <ResultRow
+          result={r}
+          expanded={expanded === r.id}
+          onToggleExpand={toggleExpand}
+          onCreateTemplate={() => {}}
+          onCreateTask={() => {}}
+          onViewTasks={() => {}}
+          onEdit={() => {}}
+          onArchive={() => {}}
+          onDelete={r.is_owner ? onDelete : undefined}
+          onMarkDone={onMarkDone}
+        />
+        {expanded === r.id && (
+          <ResultDetails
+            result={r}
+            onAddSubresult={() => {}}
+            onCreateTemplate={() => {}}
+            onCreateTask={() => {}}
+          />
+        )}
+      </React.Fragment>
+    ));
+
+  const grouped = () => {
+    const groups = {};
+    list.forEach((r) => {
+      const key = r.ownerName || '—';
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(r);
+    });
+    return Object.entries(groups).map(([owner, items]) => (
+      <div key={owner} className="results-group">
+        <h3 className="group-title">{owner}</h3>
+        {rows(items)}
+      </div>
+    ));
+  };
+
+  return (
+    <Layout>
+      <div className="results-page">
+        <div className="results-page__header">
+          <h1>Результати</h1>
+          <button className="btn primary" onClick={() => (window.location.href = '/results/new')}>
+            Додати результат
+          </button>
+        </div>
+
+        <ResultsFilters value={filters} onChange={onFiltersChange} onReset={onFiltersReset} />
+
+        {loading && <div className="results-loader">Завантаження…</div>}
+
+        {!loading && list.length === 0 && <ResultsEmpty onCreate={() => (window.location.href = '/results/new')} />}
+
+        {!loading && list.length > 0 && (
+          <div className="results-list">
+            {filters.view === 'owner' ? grouped() : rows(list)}
+          </div>
+        )}
+
+        <div className="results-pagination">
+          <button
+            className="btn ghost"
+            disabled={page <= 1}
+            onClick={() => page > 1 && setPage((p) => p - 1)}
+          >
+            Назад
+          </button>
+          <span className="page-info">
+            Сторінка {pagination.page || 1} з {pagination.pageCount || 1}
+          </span>
+          <button
+            className="btn ghost"
+            disabled={page >= pagination.pageCount}
+            onClick={() => page < pagination.pageCount && setPage((p) => p + 1)}
+          >
+            Далі
+          </button>
+        </div>
+      </div>
+    </Layout>
+  );
 }


### PR DESCRIPTION
## Summary
- replace legacy table with card-styled filters and list/grid rendering using ResultRow and ResultDetails components
- standardize filter inputs and result actions with design classes and conditional delete button

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689a70c96564833293093abad2a62681