### PR TITLE
feat: redesign daily tasks page layout

### DIFF
--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -1,353 +1,97 @@
-/* === Заголовок зі стрілками === */
-.daily-header {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 15px;
-    margin-bottom: 20px;
-}
-
-/* === Шапка сторінки з заголовком та діями === */
 .page-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
 }
 
-.page-header-title {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-}
-
-.page-header-title h1 {
-    margin: 0;
-    font-size: var(--fz-h);
-    color: var(--text);
-}
-
-.page-header-assignee {
-    font-size: var(--fz-base);
-    color: var(--text-muted);
+.page-header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .page-header-actions {
-    display: flex;
-    gap: 10px;
+  display: flex;
+  gap: 10px;
 }
 
-.page-header-actions button {
-    font-size: var(--fz-base);
-    border: none;
-    border-radius: var(--radius-sm);
-    padding: 6px 12px;
-    cursor: pointer;
-    transition: var(--transition);
+.muted {
+  color: var(--text-muted);
 }
 
-.page-header-actions .btn-add {
-    background: var(--primary);
-    color: #fff;
+.tasks-list {
+  display: grid;
 }
 
-.page-header-actions .btn-add:hover {
-    opacity: 0.9;
+.task-row {
+  display: grid;
+  grid-template-columns: 28px 1.1fr 110px 110px 1fr auto;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
 }
 
-.page-header-actions .btn-move {
-    background: var(--surface);
-    color: var(--text);
-    border: 1px solid var(--border);
+.task-row:hover {
+  box-shadow: var(--shadow);
 }
 
-.page-header-actions .btn-move:hover {
-    background: var(--bg);
+.task-row .title {
+  font-weight: 600;
+  color: var(--navy);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.date-title {
-    font-size: 22px;
-    font-weight: 600;
-    text-align: center;
-    flex-grow: 1;
-    color: #333;
+.task-row .link {
+  color: var(--blue);
+  font-size: var(--fz-sm);
+  display: block;
 }
 
-.date-arrow {
-    background: #ff6600;
-    color: #fff;
-    border: none;
-    padding: 8px 14px;
-    font-size: 18px;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.2s;
+.task-row .timer {
+  font-family: monospace;
 }
 
-.date-arrow:hover {
-    background: #e55600;
+.task-row.is-completed {
+  color: var(--text-muted);
+  text-decoration: line-through;
+  opacity: 0.7;
 }
 
-/* === Список задач === */
-.tasks-table {
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-}
-
-/* === Картка задачі === */
-.task-card {
-    background: #fff;
-    padding: 5px;
-    border-radius: 10px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
-    border: 1px solid #eee;
-    transition: all 0.2s ease;
-}
-
-.task-card:hover {
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
-}
-
-/* Виконана задача */
-.task-card.task-done {
-    opacity: 0.7;
-}
-
-.task-card.task-done .task-title {
-    text-decoration: line-through;
-    color: #777;
-}
-
-/* === Верхня частина задачі === */
-.task-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.task-complete-btn {
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: #bbb;
-    transition: color 0.2s;
-}
-
-.task-complete-btn:hover {
-    color: #ff6600;
-}
-
-.task-complete-btn.completed {
-    color: #28a745;
-    /* зелена іконка виконано */
-}
-
-.task-title {
-    flex-grow: 1;
-    font-size: 16px;
-    font-weight: 600;
-    border: none;
-    background: transparent;
-    color: #333;
-}
-
-.toggle-description {
-    background: #ff6600;
-    color: #fff;
-    border: none;
-    border-radius: 6px;
-    padding: 4px 10px;
-    cursor: pointer;
-    transition: background 0.2s;
-}
-
-.toggle-description:hover {
-    background: #e55600;
-}
-
-/* === Розгорнута частина задачі === */
 .task-details {
-    margin-top: 12px;
-    padding-top: 12px;
-    border-top: 1px dashed #ddd;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px;
+  margin-left: 40px;
+  display: grid;
+  gap: 10px;
 }
 
-/* Опис задачі */
-.task-description {
-    width: 100%;
-    min-height: 60px;
-    padding: 10px;
-    font-size: 14px;
-    margin-bottom: 12px;
-    border: 1px solid #ddd;
-    border-radius: 6px;
-    resize: vertical;
+.td-line {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
-/* === Поля в один рядок === */
-.task-fields-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    margin-bottom: 12px;
+.td-line .k {
+  font-weight: 600;
 }
 
-.task-fields-row label {
-    display: flex;
-    flex-direction: column;
-    font-size: 13px;
-    color: #444;
-    flex: 1 1 calc(33% - 12px);
+.checklist {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
 }
 
-.task-fields-row input,
-.task-fields-row select {
-    padding: 8px;
-    margin-top: 4px;
-    border: 1px solid #ccc;
-    border-radius: 6px;
-    font-size: 13px;
-    background: #fafafa;
-    transition: border 0.2s;
+.checklist li {
+  border-bottom: 1px solid var(--border);
+  padding: 4px 0;
 }
 
-.task-fields-row input:focus,
-.task-fields-row select:focus {
-    outline: none;
-    border-color: #ff6600;
-}
-
-/* === Коментарі === */
-.task-comments {
-    margin-top: 10px;
-    padding: 12px;
-    background: #f9f9f9;
-    border-radius: 8px;
-}
-
-.task-comments h4 {
-    margin-bottom: 8px;
-    font-size: 15px;
-    font-weight: 600;
-}
-
-.comment-item {
-    font-size: 14px;
-    padding: 6px 0;
-    border-bottom: 1px solid #eee;
-}
-
-.comment-item:last-child {
-    border-bottom: none;
-}
-
-.comment-replies {
-    margin-left: 15px;
-    margin-top: 5px;
-    padding-left: 10px;
-    border-left: 2px solid #ddd;
-}
-
-.comment-reply {
-    font-size: 13px;
-    color: #555;
-    padding: 4px 0;
-}
-
-/* Додавання нового коментаря */
-.add-comment {
-    display: flex;
-    margin-top: 12px;
-    gap: 8px;
-}
-
-.add-comment input {
-    flex-grow: 1;
-    padding: 8px;
-    font-size: 13px;
-    border: 1px solid #ddd;
-    border-radius: 6px;
-    background: #fff;
-}
-
-.add-comment button {
-    background: #ff6600;
-    color: #fff;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.2s;
-}
-
-.add-comment button:hover {
-    background: #e55600;
-}
-
-/* === Сумарний час === */
 .tasks-summary {
-    margin-top: 20px;
-    background: #fff;
-    padding: 15px;
-    border-radius: 8px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-    display: flex;
-    justify-content: space-between;
-    font-size: 15px;
-    font-weight: 500;
+  margin-top: 20px;
 }
 
-
-.task-type-badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 6px;
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 1.4;
-    min-width: max-content;
-    margin-left: 4px;
-    /* невеликий відступ від дати */
-}
-
-.task-timer-info {
-    font-size: 12px;
-    color: #333;
-    background: #eef6ff;
-    /* світло-блакитний фон */
-    padding: 2px 6px;
-    border-radius: 6px;
-    border: 1px solid #cce0ff;
-    margin-right: 6px;
-    /* відступ перед датою */
-}
-
-.task-due-date {
-    font-size: 12px;
-    color: #666;
-    margin-right: 4px;
-    /* щоб не злипалось із типом */
-}
-
-.react-datepicker__month-container {
-    position: fixed;
-    /* робимо попап */
-    top: 50%;
-    /* по центру вертикально */
-    left: 50%;
-    /* по центру горизонтально */
-    transform: translate(-50%, -50%);
-    z-index: 9999;
-    /* поверх інших елементів */
-
-    background: #fff;
-    /* фон попапу */
-    border: 1px solid #ddd;
-    /* рамка */
-    border-radius: 8px;
-    /* заокруглення */
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-    /* тінь */
-    padding: 10px;
-}


### PR DESCRIPTION
## Summary
- redesign DailyTasksPage to use compact grid rows with inline timer controls and expandable details
- add search and filter toolbar with reset option for daily tasks
- add page-level styles for new task list and summary block

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689a70e02af48332b0965e5d3b50727a