### PR TITLE
feat: add org structure demo components

### DIFF
--- a/src/modules/org/components/OrgCanvas.css
+++ b/src/modules/org/components/OrgCanvas.css
@@ -1,0 +1,19 @@
+@import "../../../styles/variables.css";
+@import "./OrgNode.css";
+
+.org-canvas-viewport{
+  position:relative; width:100%; height:100%;
+  overflow:auto; background: var(--bg);
+}
+
+.org-canvas-inner{
+  position:relative; width:max-content; min-width:100%; min-height:100%;
+  transform-origin: 0 0;
+  cursor: grab;
+}
+
+.org-canvas-controls{
+  position:absolute; top:12px; right:12px; display:flex; gap:6px; z-index:2;
+}
+
+.org-column{ margin:20px; }

--- a/src/modules/org/components/OrgCanvas.jsx
+++ b/src/modules/org/components/OrgCanvas.jsx
@@ -1,0 +1,70 @@
+import React, { useMemo, useRef, useState } from "react";
+import OrgNode from "./OrgNode";
+
+/**
+ * props:
+ * - tree: [{ division }]
+ * - expanded: Set<string>
+ * - onToggleExpand(key)
+ * - highlightIds: Set<string>
+ * - onUpdateUnit(id, patch)
+ * - onMove({ entity:'department'|'position', id, targetId })
+ * - onReplaceUser(positionId, newUser)
+ */
+export default function OrgCanvas({
+  tree, expanded, onToggleExpand, highlightIds,
+  onUpdateUnit, onMove, onReplaceUser
+}) {
+  const viewportRef = useRef(null);
+  const [zoom, setZoom] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(null);
+
+  const onWheel = (e) => {
+    if (e.ctrlKey) {
+      e.preventDefault();
+      const factor = e.deltaY > 0 ? 0.9 : 1.1;
+      setZoom(z => Math.min(2, Math.max(0.5, z * factor)));
+    }
+  };
+
+  const startPan = (e) => { setDragging({ x: e.clientX, y: e.clientY, orig: offset }); };
+  const onMouseMove = (e) => {
+    if (!dragging) return;
+    setOffset({ x: dragging.orig.x + (e.clientX - dragging.x), y: dragging.orig.y + (e.clientY - dragging.y) });
+  };
+  const endPan = () => setDragging(null);
+
+  const resetView = () => { setZoom(1); setOffset({x:0,y:0}); };
+
+  return (
+    <div className="org-canvas-viewport" ref={viewportRef} onWheel={onWheel} onMouseMove={onMouseMove} onMouseUp={endPan} onMouseLeave={endPan}>
+      <div className="org-canvas-controls">
+        <button className="btn ghost" onClick={()=>setZoom(z=>Math.min(2, z+0.1))}>+</button>
+        <button className="btn ghost" onClick={()=>setZoom(z=>Math.max(0.5, z-0.1))}>−</button>
+        <button className="btn ghost" onClick={resetView}>Reset view</button>
+      </div>
+
+      <div
+        className="org-canvas-inner"
+        style={{ transform: `translate(${offset.x}px, ${offset.y}px) scale(${zoom})` }}
+        onMouseDown={startPan}
+      >
+        {tree.map((div) => (
+          <div key={div.id} className="org-column">
+            <OrgNode
+              node={div}
+              level={0}
+              expanded={expanded}
+              onToggleExpand={onToggleExpand}
+              highlightIds={highlightIds}
+              onUpdateUnit={onUpdateUnit}
+              onMove={onMove}
+              onReplaceUser={onReplaceUser}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/org/components/OrgLeftPanel.css
+++ b/src/modules/org/components/OrgLeftPanel.css
@@ -1,0 +1,22 @@
+@import "../../../styles/variables.css";
+
+.org-left-panel{ display:grid; gap:12px; }
+
+.olp-filters{ display:grid; gap:10px; }
+
+.rf-search{
+  display:flex; align-items:center; gap:10px;
+  border:1px solid var(--border); border-radius: var(--radius-sm);
+  padding:6px 10px; background:#fff;
+}
+.rf-search .ico{ width:18px; height:18px; color: var(--text-muted); }
+.rf-field{ display:flex; flex-direction:column; gap:6px; font-size: var(--fz-sm); color: var(--text-muted); }
+.olp-row{ display:flex; flex-wrap:wrap; gap:10px; align-items:flex-end; }
+
+.olp-table{ display:grid; gap:0; border:1px solid var(--border); border-radius: var(--radius); overflow:hidden; background:#fff; }
+.olp-th, .olp-tr{ display:grid; grid-template-columns: 1.3fr 1fr 1fr auto; gap:12px; align-items:center; padding:10px 12px; }
+.olp-th{ background: var(--surface-muted); font-weight:600; color: var(--navy); }
+.olp-tr{ border-top:1px solid var(--border); }
+.olp-tr .title{ font-weight:600; color: var(--text); }
+.olp-tr .muted{ color: var(--text-muted); font-size: var(--fz-sm); }
+.olp-tr .actions{ display:flex; gap:6px; justify-content:flex-end; }

--- a/src/modules/org/components/OrgLeftPanel.jsx
+++ b/src/modules/org/components/OrgLeftPanel.jsx
@@ -1,0 +1,106 @@
+import React from "react";
+
+/**
+ * props:
+ * - positions: [{id,title,user,managers[],departmentId,divisionId,departmentName,divisionName}]
+ * - allPositions: [] (для селектів)
+ * - filters: { q, divisionId, departmentId, role }
+ * - onFiltersChange(next)
+ * - onSearch(q)
+ * - onUpdatePosition(id, patch) // { managers:[], departmentId }
+ */
+export default function OrgLeftPanel({
+  positions, allPositions, filters, onFiltersChange, onSearch, onUpdatePosition
+}) {
+  const divisions = uniquePairs(allPositions.map(p => ({ id: p.divisionId, name: p.divisionName })));
+  const departments = uniquePairs(allPositions.map(p => ({ id: p.departmentId, name: p.departmentName })));
+
+  return (
+    <div className="org-left-panel">
+      <div className="olp-filters">
+        <label className="rf-search" aria-label="Пошук">
+          <svg viewBox="0 0 24 24" className="ico" aria-hidden="true">
+            <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" fill="none" />
+            <line x1="21" y1="21" x2="16.5" y2="16.5" stroke="currentColor" strokeWidth="2" />
+          </svg>
+          <input
+            className="input"
+            type="search"
+            placeholder="Пошук ПІБ/посади/відділу…"
+            value={filters.q}
+            onChange={(e)=>{ onSearch && onSearch(e.target.value); }}
+          />
+        </label>
+
+        <div className="olp-row">
+          <label className="rf-field">
+            <span>Відділення</span>
+            <select className="input" value={filters.divisionId} onChange={(e)=>onFiltersChange({...filters, divisionId: e.target.value})}>
+              <option value="any">Усі</option>
+              {divisions.map(d=> <option key={d.id} value={d.id}>{d.name}</option>)}
+            </select>
+          </label>
+
+          <label className="rf-field">
+            <span>Відділ</span>
+            <select className="input" value={filters.departmentId} onChange={(e)=>onFiltersChange({...filters, departmentId: e.target.value})}>
+              <option value="any">Усі</option>
+              {departments.map(d=> <option key={d.id} value={d.id}>{d.name}</option>)}
+            </select>
+          </label>
+
+          <label className="rf-field">
+            <span>Роль</span>
+            <select className="input" value={filters.role} onChange={(e)=>onFiltersChange({...filters, role: e.target.value})}>
+              <option value="any">Будь‑яка</option>
+              <option value="manager">Керівник</option>
+              <option value="employee">Співробітник</option>
+            </select>
+          </label>
+
+          <button className="btn ghost" onClick={()=>onFiltersChange({ q:"", divisionId:"any", departmentId:"any", role:"any" })}>Скинути</button>
+        </div>
+      </div>
+
+      <div className="olp-table">
+        <div className="olp-th">
+          <div>Посада</div>
+          <div>Керівник(и)</div>
+          <div>Відділ</div>
+          <div>Дії</div>
+        </div>
+
+        {positions.map(p => (
+          <div className="olp-tr" key={p.id}>
+            <div className="name">
+              <div className="title">{p.title}</div>
+              <div className="muted">{p.user?.name || "—"}</div>
+            </div>
+
+            <div className="managers">
+              <input className="input" placeholder="введіть ПІБ (демо)" defaultValue={(p.managers||[]).map(m=>m.name).join(", ")}
+                onBlur={(e)=>onUpdatePosition && onUpdatePosition(p.id, { managersText: e.target.value })} />
+            </div>
+
+            <div className="dept">
+              <select className="input" defaultValue={p.departmentId} onChange={(e)=>onUpdatePosition && onUpdatePosition(p.id, { departmentId: e.target.value })}>
+                {departments.map(d=> <option key={d.id} value={d.id}>{d.name}</option>)}
+              </select>
+            </div>
+
+            <div className="actions">
+              <a className="btn ghost" href={`/tasks?assignee_id=${p.user?.id || ""}`}>Задачі</a>
+              <a className="btn ghost" href={`/results?assignee_id=${p.user?.id || ""}`}>Результати</a>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function uniquePairs(arr){
+  const map = new Map();
+  arr.forEach(({id,name}) => { if(id && !map.has(id)) map.set(id, name); });
+  return [...map.entries()].map(([id,name]) => ({id,name}));
+}

--- a/src/modules/org/components/OrgNode.css
+++ b/src/modules/org/components/OrgNode.css
@@ -1,0 +1,47 @@
+@import "../../../styles/variables.css";
+
+.org-node{
+  background:#fff;
+  border:1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding:10px;
+  min-width:220px;
+  max-width:360px;
+  margin:10px;
+}
+
+.org-node .head{
+  display:flex; align-items:center; gap:8px; margin-bottom:8px;
+}
+.org-node .caret{
+  width:28px; height:28px; border:1px solid var(--border);
+  background:#fff; border-radius:8px; cursor:pointer;
+}
+.org-node .title{
+  font-weight:600; color:var(--navy); flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+}
+.org-node .badge{ margin-left:auto; }
+
+.unit-meta .line,
+.pos-meta .line{
+  display:flex; align-items:center; gap:8px; margin-top:6px;
+}
+.line .k{ color: var(--text-muted); min-width:80px; }
+
+.unit-actions, .pos-actions{ display:flex; gap:6px; margin-top:8px; flex-wrap:wrap; }
+
+.children{
+  display:flex; flex-wrap:wrap; align-items:flex-start; margin-top:6px; padding-left:18px;
+  border-left:2px dashed color-mix(in srgb, var(--navy) 20%, transparent);
+}
+
+/* типи вузлів */
+.is-division{ border-color: color-mix(in srgb, var(--blue) 30%, var(--border)); }
+.is-department{ border-color: color-mix(in srgb, var(--rush) 30%, var(--border)); }
+.is-position{ border-color: color-mix(in srgb, var(--navy) 25%, var(--border)); }
+
+/* підсвітка пошуку та DnD */
+.is-highlighted{ outline:2px solid var(--blue); box-shadow:0 0 0 4px color-mix(in srgb, var(--blue) 15%, transparent); }
+.droppable-ok{ outline:2px dashed #10B981; }
+.droppable-deny{ outline:2px dashed #EF4444; }

--- a/src/modules/org/components/OrgNode.jsx
+++ b/src/modules/org/components/OrgNode.jsx
@@ -1,0 +1,132 @@
+import React, { useState } from "react";
+
+/**
+ * Рекурсивний вузол оргструктури.
+ * node.type: 'division' | 'department' | 'position'
+ */
+export default function OrgNode({
+  node, level, expanded, onToggleExpand, highlightIds,
+  onUpdateUnit, onMove, onReplaceUser
+}) {
+  const key = node.id;
+  const isOpen = expanded.has(key);
+  const isHighlighted = highlightIds?.has(key);
+
+  // DnD
+  const [dragOverState, setDragOverState] = useState(null); // 'ok'|'deny'|null
+  const dragStart = (e) => { e.dataTransfer.setData("text/plain", JSON.stringify({ entity: node.type, id: node.id })); };
+  const dragOver = (e) => {
+    e.preventDefault();
+    // allow drop: position -> department; department -> division
+    const data = JSON.parse(e.dataTransfer.getData("text/plain") || "{}");
+    const ok = (data.entity === "position" && node.type === "department")
+            || (data.entity === "department" && node.type === "division");
+    setDragOverState(ok ? "ok" : "deny");
+  };
+  const drop = (e) => {
+    e.preventDefault();
+    const data = JSON.parse(e.dataTransfer.getData("text/plain") || "{}");
+    const ok = (data.entity === "position" && node.type === "department")
+            || (data.entity === "department" && node.type === "division");
+    if (ok) {
+      onMove && onMove({ entity: data.entity, id: data.id, targetId: node.id });
+    }
+    setDragOverState(null);
+  };
+  const dragLeave = () => setDragOverState(null);
+
+  return (
+    <div
+      className=
+        {"org-node " +
+        (node.type === "division" ? "is-division " : node.type === "department" ? "is-department " : "is-position ") +
+        (isHighlighted ? "is-highlighted " : "") +
+        (dragOverState === "ok" ? "droppable-ok " : dragOverState === "deny" ? "droppable-deny " : "")
+      }
+      draggable={node.type !== "division"}
+      onDragStart={dragStart}
+      onDragOver={dragOver}
+      onDrop={drop}
+      onDragLeave={dragLeave}
+    >
+      <div className="head">
+        {node.type !== "position" && (
+          <button className="caret" onClick={()=>onToggleExpand && onToggleExpand(key)}>{isOpen ? "▾" : "▸"}</button>
+        )}
+        <div className="title">{node.name || node.title}</div>
+        {node.head && (node.type !== "position") && <span className="badge important">Керівник: {node.head.name}</span>}
+      </div>
+
+      {node.type === "position" && (
+        <div className="pos-meta">
+          <div className="muted">Працівник</div>
+          <div className="user">{node.user?.name || "—"}</div>
+          <div className="pos-actions">
+            <a className="btn ghost" href={`/tasks?assignee_id=${node.user?.id || ""}`}>Задачі</a>
+            <a className="btn ghost" href={`/results?assignee_id=${node.user?.id || ""}`}>Результати</a>
+          </div>
+          <label className="line">
+            <span className="k">Старий</span>
+            <input className="input" disabled value={node.user?.name || ""} />
+          </label>
+          <label className="line">
+            <span className="k">Новий</span>
+            <input className="input" placeholder="вибрати (демо)" onBlur={(e)=>onReplaceUser && onReplaceUser(node.id, { id: -1, name: e.target.value })} />
+          </label>
+        </div>
+      )}
+
+      {node.type !== "position" && (
+        <div className="unit-meta">
+          <label className="line">
+            <span className="k">ЦКП</span>
+            <textarea
+              className="input"
+              rows={2}
+              defaultValue={node.productValue || ""}
+              onBlur={(e)=>onUpdateUnit && onUpdateUnit(node.id, { productValue: e.target.value })}
+            />
+          </label>
+          <div className="unit-actions">
+            <button className="btn ghost">Додати відділ</button>
+            <button className="btn ghost">Додати посаду</button>
+            <button className="btn ghost">Редагувати</button>
+            <button className="btn ghost">Видалити</button>
+          </div>
+        </div>
+      )}
+
+      {/* діти */}
+      {node.type !== "position" && isOpen && (
+        <div className="children">
+          {node.type === "division" && (node.departments || []).map(dep => (
+            <OrgNode
+              key={dep.id}
+              node={dep}
+              level={level+1}
+              expanded={expanded}
+              onToggleExpand={onToggleExpand}
+              highlightIds={highlightIds}
+              onUpdateUnit={onUpdateUnit}
+              onMove={onMove}
+              onReplaceUser={onReplaceUser}
+            />
+          ))}
+          {node.type === "department" && (node.employees || []).map(p => (
+            <OrgNode
+              key={p.id}
+              node={p}
+              level={level+1}
+              expanded={expanded}
+              onToggleExpand={onToggleExpand}
+              highlightIds={highlightIds}
+              onUpdateUnit={onUpdateUnit}
+              onMove={onMove}
+              onReplaceUser={onReplaceUser}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/org/pages/OrgPage.css
+++ b/src/modules/org/pages/OrgPage.css
@@ -1,75 +1,20 @@
-.org-layout {
-  display: grid;
+@import "../../../styles/variables.css";
+
+.org-layout{
+  display:grid;
   grid-template-columns: 360px 1fr;
-  height: 100%;
+  gap:0;
+  height:100%;
 }
 
-.org-left {
-  padding: 12px;
-  border-right: 1px solid var(--border);
+.org-left{
+  padding:12px;
+  border-right:1px solid var(--border);
+  background:#fff;
 }
 
-.org-canvas {
-  position: relative;
-  overflow: auto;
+.org-canvas{
+  position:relative;
+  overflow:auto;
   background: var(--bg);
-}
-
-.org-canvas-inner {
-  transform-origin: 0 0;
-}
-
-.org-node {
-  background: #fff;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-sm);
-  padding: 10px;
-  min-width: 220px;
-  margin: 8px;
-}
-
-.org-node .title {
-  font-weight: 600;
-  color: var(--navy);
-}
-
-.org-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 8px;
-}
-
-.org-filters .rf-search {
-  flex: 1 1 100%;
-}
-
-.org-table td .btn.ghost {
-  padding: 0;
-}
-
-.product-value {
-  resize: vertical;
-}
-
-.zoom-controls {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  display: flex;
-  gap: 4px;
-}
-
-.is-highlighted {
-  outline: 2px solid var(--blue);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--blue) 15%, transparent);
-}
-
-.droppable-ok {
-  outline: 2px dashed #10B981;
-}
-
-.droppable-deny {
-  outline: 2px dashed #EF4444;
 }

--- a/src/modules/org/pages/OrgPage.jsx
+++ b/src/modules/org/pages/OrgPage.jsx
@@ -1,233 +1,211 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import Layout from "../../../components/layout/Layout";
-import axios from "axios";
-import { API_BASE_URL } from "../../../config";
+import "../components/OrgLeftPanel.css";
+import "../components/OrgCanvas.css";
 import "./OrgPage.css";
 
+import OrgLeftPanel from "../components/OrgLeftPanel";
+import OrgCanvas from "../components/OrgCanvas";
+
+/**
+ * OrgPage – контейнер сторінки оргструктури.
+ * TODO: Підключити реальні дані через API:
+ *   - GET /org/tree         -> setTree(...)
+ *   - GET /org/positions    -> setPositions(...)
+ *   - PATCH/POST/DELETE ... -> передати у хендлери нижче
+ */
 export default function OrgPage() {
-    const [positions, setPositions] = useState([]);
-    const [tree, setTree] = useState([]);
-    const [search, setSearch] = useState("");
-    const [highlightedIds, setHighlightedIds] = useState([]);
+  // ----- demo state (замінити на дані API)
+  const [tree, setTree] = useState(() => demoTree());
+  const [positions, setPositions] = useState(() => demoPositions(tree));
+  const [filters, setFilters] = useState({ q: "", divisionId: "any", departmentId: "any", role: "any" });
+  const [highlightIds, setHighlightIds] = useState(new Set());
+  const [expanded, setExpanded] = useState(() => loadExpanded());
 
-    const nodeRefs = useRef({});
-    const canvasRef = useRef(null);
-    const [scale, setScale] = useState(1);
+  // пошук у лівій панелі -> підсвітити вузли на канвасі
+  const handleSearch = (q) => {
+    setFilters((f) => ({ ...f, q }));
+    const ids = new Set(findNodeIdsByQuery(tree, q));
+    setHighlightIds(ids);
+  };
 
-    useEffect(() => {
-        axios.get(`${API_BASE_URL}/org/positions`).then((res) => setPositions(res.data || [])).catch(() => {});
-        axios.get(`${API_BASE_URL}/org/tree`).then((res) => setTree(res.data || [])).catch(() => {});
-    }, []);
+  // оновлення unit/position (inline-редагування, продукт, керівники тощо)
+  const handleUpdateUnit = (id, patch) => {
+    setTree((prev) => updateUnit(prev, id, patch));
+    // TODO: PATCH /org/unit/{id}
+  };
+  const handleUpdatePosition = (id, patch) => {
+    setPositions((prev) => prev.map(p => p.id === id ? { ...p, ...patch } : p));
+    // TODO: PATCH /org/position/{id}
+  };
 
-    const filteredPositions = useMemo(() => {
-        if (!search) return positions;
-        const q = search.toLowerCase();
-        return positions.filter((p) => {
-            const dept = p.department?.name || "";
-            const managers = (p.managers || []).map((m) => m.name).join(" ");
-            return (
-                p.name.toLowerCase().includes(q) ||
-                dept.toLowerCase().includes(q) ||
-                managers.toLowerCase().includes(q)
-            );
-        });
-    }, [positions, search]);
+  // DnD переміщення
+  const handleMove = ({ entity, id, targetId }) => {
+    setTree((prev) => moveEntity(prev, entity, id, targetId));
+    // TODO: PATCH /org/move { entity, id, targetId }
+  };
 
-    useEffect(() => {
-        const q = search.toLowerCase();
-        if (!q) {
-            setHighlightedIds([]);
-            return;
-        }
-        const ids = [];
-        const walk = (units) => {
-            units.forEach((u) => {
-                if (u.name?.toLowerCase().includes(q)) ids.push(`unit-${u.id}`);
-                (u.departments || []).forEach(walk);
-                (u.employees || []).forEach((e) => {
-                    if (
-                        e.name?.toLowerCase().includes(q) ||
-                        e.position?.toLowerCase().includes(q)
-                    ) {
-                        ids.push(`emp-${e.id}`);
-                    }
-                });
-            });
-        };
-        walk(tree);
-        setHighlightedIds(ids);
-    }, [search, tree]);
+  // заміна працівника в позиції
+  const handleReplaceUser = (positionId, newUser) => {
+    setPositions((prev) => prev.map(p => p.id === positionId ? { ...p, user: newUser } : p));
+    // TODO: PATCH /org/position/{id}/replaceUser
+  };
 
-    const scrollToNode = (id) => {
-        const el = nodeRefs.current[id];
-        if (el) el.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
-        setHighlightedIds([id]);
-    };
+  // зберігати стан розгортання
+  const toggleExpand = (nodeKey) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(nodeKey) ? next.delete(nodeKey) : next.add(nodeKey);
+      localStorage.setItem("org.expanded", JSON.stringify([...next]));
+      return next;
+    });
+  };
 
-    const renderEmployees = (arr) => (
-        <div className="org-children">
-            {arr.map((e) => (
-                <div
-                    key={`emp-${e.id}`}
-                    ref={(el) => (nodeRefs.current[`emp-${e.id}`] = el)}
-                    className={`org-node org-employee ${
-                        highlightedIds.includes(`emp-${e.id}`) ? "is-highlighted" : ""
-                    }`}
-                >
-                    <div className="title">{e.name}</div>
-                    <div className="muted">{e.position}</div>
-                    {e.isManager && <span className="badge important">Керівник</span>}
-                </div>
-            ))}
-        </div>
-    );
+  // фільтровані позиції для лівої панелі
+  const filteredPositions = useMemo(
+    () => filterPositions(positions, filters),
+    [positions, filters]
+  );
 
-    const renderDepartments = (arr) => (
-        <div className="org-level">
-            {arr.map((dep) => (
-                <div
-                    key={`unit-${dep.id}`}
-                    ref={(el) => (nodeRefs.current[`unit-${dep.id}`] = el)}
-                    className={`org-node ${
-                        highlightedIds.includes(`unit-${dep.id}`) ? "is-highlighted" : ""
-                    }`}
-                >
-                    <div className="title">{dep.name}</div>
-                    {dep.head && <div className="badge neutral">{dep.head.name}</div>}
-                    {dep.productValue && (
-                        <textarea
-                            className="input product-value"
-                            defaultValue={dep.productValue}
-                            rows={2}
-                        />
-                    )}
-                    {dep.employees && dep.employees.length > 0 &&
-                        renderEmployees(dep.employees)}
-                </div>
-            ))}
-        </div>
-    );
+  return (
+    <div className="org-layout">
+      <aside className="org-left card">
+        <OrgLeftPanel
+          positions={filteredPositions}
+          allPositions={positions}
+          filters={filters}
+          onFiltersChange={setFilters}
+          onSearch={handleSearch}
+          onUpdatePosition={handleUpdatePosition}
+        />
+      </aside>
 
-    const renderTree = () => (
-        <div className="org-level">
-            {tree.map((div) => (
-                <div
-                    key={`unit-${div.id}`}
-                    ref={(el) => (nodeRefs.current[`unit-${div.id}`] = el)}
-                    className={`org-node ${
-                        highlightedIds.includes(`unit-${div.id}`) ? "is-highlighted" : ""
-                    }`}
-                >
-                    <div className="title">{div.name}</div>
-                    {div.head && <div className="badge neutral">{div.head.name}</div>}
-                    {div.productValue && (
-                        <textarea
-                            className="input product-value"
-                            defaultValue={div.productValue}
-                            rows={2}
-                        />
-                    )}
-                    {div.departments && div.departments.length > 0 &&
-                        renderDepartments(div.departments)}
-                </div>
-            ))}
-        </div>
-    );
-
-    const onWheel = (e) => {
-        if (e.ctrlKey) {
-            e.preventDefault();
-            setScale((s) => Math.min(2, Math.max(0.5, s - e.deltaY * 0.01)));
-        }
-    };
-    const zoomIn = () => setScale((s) => Math.min(2, s + 0.1));
-    const zoomOut = () => setScale((s) => Math.max(0.5, s - 0.1));
-    const resetView = () => {
-        setScale(1);
-        if (canvasRef.current) {
-            canvasRef.current.scrollLeft = 0;
-            canvasRef.current.scrollTop = 0;
-        }
-    };
-
-    return (
-        <Layout>
-            <h1>Орг. структура</h1>
-            <div className="org-layout">
-                <aside className="org-left card">
-                    <div className="org-filters">
-                        <label className="rf-search">
-                            <input
-                                className="input"
-                                type="search"
-                                placeholder="Пошук ПІБ/посади/відділу…"
-                                value={search}
-                                onChange={(e) => setSearch(e.target.value)}
-                            />
-                        </label>
-                        <select className="input">
-                            <option>Відділення</option>
-                        </select>
-                        <select className="input">
-                            <option>Відділ</option>
-                        </select>
-                        <select className="input">
-                            <option>Роль</option>
-                        </select>
-                        <button className="btn ghost" onClick={() => setSearch("")}>Скинути фільтри</button>
-                    </div>
-                    <button className="btn primary add-pos">Додати посаду</button>
-                    <table className="table org-table">
-                        <thead>
-                            <tr>
-                                <th>Посада</th>
-                                <th>Керівник(и)</th>
-                                <th>Відділ</th>
-                                <th>Дії</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {filteredPositions.map((p) => (
-                                <tr key={p.id}>
-                                    <td>
-                                        <button
-                                            className="btn ghost"
-                                            onClick={() => scrollToNode(`emp-${p.id}`)}
-                                        >
-                                            {p.name}
-                                        </button>
-                                    </td>
-                                    <td>{(p.managers || []).map((m) => m.name).join(", ")}</td>
-                                    <td>{p.department?.name}</td>
-                                    <td>
-                                        <button className="btn ghost">Перейти</button>
-                                        <button className="btn ghost">Видалити</button>
-                                        <button className="btn ghost">Перемістити</button>
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </aside>
-                <main
-                    className="org-canvas"
-                    onWheel={onWheel}
-                    ref={canvasRef}
-                >
-                    <div className="zoom-controls">
-                        <button className="btn ghost" onClick={zoomIn}>+</button>
-                        <button className="btn ghost" onClick={zoomOut}>−</button>
-                        <button className="btn ghost" onClick={resetView}>Reset view</button>
-                    </div>
-                    <div
-                        className="org-canvas-inner"
-                        style={{ transform: `scale(${scale})`, transformOrigin: "0 0" }}
-                    >
-                        {renderTree()}
-                    </div>
-                </main>
-            </div>
-        </Layout>
-    );
+      <main className="org-canvas">
+        <OrgCanvas
+          tree={tree}
+          expanded={expanded}
+          onToggleExpand={toggleExpand}
+          highlightIds={highlightIds}
+          onUpdateUnit={handleUpdateUnit}
+          onMove={handleMove}
+          onReplaceUser={handleReplaceUser}
+        />
+      </main>
+    </div>
+  );
 }
 
+/* ----------------- helpers / demo data (замінити API) ----------------- */
+function demoTree() {
+  return [
+    {
+      id: "div1", type: "division", name: "Відділення А",
+      head: { id: 101, name: "Олена Р." },
+      productValue: "Планування і P&L підрозділу",
+      order: 1,
+      departments: [
+        {
+          id: "dep1", type: "department", name: "Відділ Продажів", head: { id: 102, name: "Ігор С." },
+          productValue: "Нові контракти",
+          order: 1,
+          employees: [
+            { id: "pos1", type: "position", title: "Менеджер з продажу", user: { id: 201, name: "Наталія К." }, isManager: false },
+            { id: "pos2", type: "position", title: "Аккаунт-менеджер", user: { id: 202, name: "Дмитро П." }, isManager: false }
+          ]
+        },
+        {
+          id: "dep2", type: "department", name: "Маркетинг", head: { id: 103, name: "Світлана Л." },
+          productValue: "Ліди і бренд",
+          order: 2,
+          employees: [
+            { id: "pos3", type: "position", title: "Контент-маркетолог", user: { id: 203, name: "Марія Д." }, isManager: false }
+          ]
+        }
+      ]
+    }
+  ];
+}
+function demoPositions(tree) {
+  const out = [];
+  tree.forEach(div => {
+    div.departments.forEach(dep => {
+      dep.employees.forEach(p => out.push({
+        id: p.id, title: p.title, user: p.user, managers: dep.head ? [dep.head] : [],
+        departmentId: dep.id, divisionId: div.id, departmentName: dep.name, divisionName: div.name
+      }));
+    });
+  });
+  return out;
+}
+function findNodeIdsByQuery(tree, q) {
+  if (!q) return [];
+  const s = q.toLowerCase();
+  const ids = [];
+  const walk = (d) => {
+    d.forEach(div => {
+      if (div.name.toLowerCase().includes(s) || (div.head?.name || "").toLowerCase().includes(s)) ids.push(div.id);
+      div.departments.forEach(dep => {
+        if (dep.name.toLowerCase().includes(s) || (dep.head?.name || "").toLowerCase().includes(s)) ids.push(dep.id);
+        dep.employees.forEach(p => {
+          if ((p.title || "").toLowerCase().includes(s) || (p.user?.name || "").toLowerCase().includes(s)) ids.push(p.id);
+        });
+      });
+    });
+  };
+  walk(tree);
+  return ids;
+}
+function filterPositions(list, f) {
+  return list.filter(p => {
+    if (f.q) {
+      const s = f.q.toLowerCase();
+      const hit = (p.title||"").toLowerCase().includes(s)
+        || (p.user?.name||"").toLowerCase().includes(s)
+        || (p.departmentName||"").toLowerCase().includes(s)
+        || (p.divisionName||"").toLowerCase().includes(s);
+      if (!hit) return false;
+    }
+    if (f.divisionId !== "any" && p.divisionId !== f.divisionId) return false;
+    if (f.departmentId !== "any" && p.departmentId !== f.departmentId) return false;
+    if (f.role === "manager" && !p.isManager) return false;
+    return true;
+  });
+}
+function updateUnit(tree, id, patch) {
+  const next = JSON.parse(JSON.stringify(tree));
+  const apply = (node) => {
+    if (node.id === id) Object.assign(node, patch);
+    if (node.departments) node.departments.forEach(apply);
+  };
+  next.forEach(apply);
+  return next;
+}
+function moveEntity(tree, entity, id, targetId) {
+  const next = JSON.parse(JSON.stringify(tree));
+  let dragged = null;
+  // remove
+  next.forEach(div => {
+    div.departments = div.departments.filter(dep => {
+      if (entity === "department" && dep.id === id) { dragged = dep; return false; }
+      dep.employees = dep.employees.filter(p => {
+        if (entity === "position" && p.id === id) { dragged = p; return false; }
+        return true;
+      });
+      return true;
+    });
+  });
+  // insert
+  if (dragged) {
+    next.forEach(div => {
+      if (entity === "department" && div.id === targetId) {
+        div.departments.push(dragged);
+      }
+      div.departments.forEach(dep => {
+        if (entity === "position" && dep.id === targetId) dep.employees.push(dragged);
+      });
+    });
+  }
+  return next;
+}
+function loadExpanded() {
+  try { return new Set(JSON.parse(localStorage.getItem("org.expanded") || "[]")); } catch { return new Set(); }
+}


### PR DESCRIPTION
## Summary
- build OrgPage container using demo data, filters, drag and drop and unit editing handlers
- add left panel with search and position management
- render zoomable org chart canvas with recursive nodes and drag-and-drop

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689a7ac1499c833289a75c091dc77302