### PR TITLE
feat: add business processes page

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -14,6 +14,7 @@ import {
     FiChevronDown,
     FiBook,
     FiExternalLink,
+    FiGitBranch,
 } from "react-icons/fi";
 import CheckToggle from "../../ui/CheckToggle";
 import axios from "axios";
@@ -111,6 +112,21 @@ export default function Sidebar({
                                 {isOpen && (
                                     <span className="menu-text">
                                         Щоденні задачі
+                                    </span>
+                                )}
+                            </NavLink>
+                        </li>
+                        <li>
+                            <NavLink
+                                to="/business-processes"
+                                className={({ isActive }) =>
+                                    isActive ? "active" : ""
+                                }
+                            >
+                                <FiGitBranch className="menu-icon" />
+                                {isOpen && (
+                                    <span className="menu-text">
+                                        Бізнес-процеси
                                     </span>
                                 )}
                             </NavLink>

--- a/src/modules/processes/pages/BusinessProcessesPage.css
+++ b/src/modules/processes/pages/BusinessProcessesPage.css
@@ -1,0 +1,35 @@
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.page-header-left {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.page-header-actions {
+    display: flex;
+    gap: 10px;
+}
+
+.processes-table .actions {
+    display: flex;
+    gap: 6px;
+}
+
+.link-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--blue);
+    cursor: pointer;
+    font: inherit;
+}
+
+.link-btn:hover {
+    text-decoration: underline;
+}

--- a/src/modules/processes/pages/BusinessProcessesPage.jsx
+++ b/src/modules/processes/pages/BusinessProcessesPage.jsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+import Layout from "../../../components/layout/Layout";
+import "./BusinessProcessesPage.css";
+
+export default function BusinessProcessesPage() {
+    const [query, setQuery] = useState("");
+
+    const processes = [
+        {
+            id: 1,
+            name: "Онбординг співробітника",
+            description: "Послідовність дій для прийому нового працівника",
+            createdAt: "2024-08-01",
+            updatedAt: "2024-09-15",
+            elements: 12,
+        },
+        {
+            id: 2,
+            name: "Закупівлі",
+            description: "Процес придбання обладнання та матеріалів",
+            createdAt: "2024-07-10",
+            updatedAt: "2024-08-20",
+            elements: 8,
+        },
+    ];
+
+    const filtered = processes.filter((p) => {
+        const q = query.toLowerCase();
+        return (
+            p.name.toLowerCase().includes(q) ||
+            p.description.toLowerCase().includes(q)
+        );
+    });
+
+    const onEdit = (id) => {
+        window.alert(`Редагувати процес ${id}`);
+    };
+
+    const onClone = (id) => {
+        window.alert(`Клонувати процес ${id}`);
+    };
+
+    const onDelete = (id) => {
+        window.alert(`Видалити процес ${id}`);
+    };
+
+    return (
+        <Layout>
+            <div className="page-header">
+                <div className="page-header-left">
+                    <h1>Бізнес-процеси</h1>
+                    <input
+                        type="search"
+                        className="input"
+                        placeholder="Пошук..."
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                    />
+                </div>
+                <div className="page-header-actions">
+                    <button className="btn primary" onClick={() => window.alert("Додати процес")}>Додати процес</button>
+                </div>
+            </div>
+
+            <table className="table processes-table">
+                <thead>
+                    <tr>
+                        <th>Назва процесу</th>
+                        <th>Короткий опис</th>
+                        <th>Дата створення</th>
+                        <th>Дата останнього редагування</th>
+                        <th style={{ textAlign: "right" }}>Кількість елементів</th>
+                        <th>Дії</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {filtered.map((p) => (
+                        <tr key={p.id} className="row-hover">
+                            <td>
+                                <button className="link-btn" onClick={() => onEdit(p.id)}>
+                                    {p.name}
+                                </button>
+                            </td>
+                            <td>{p.description}</td>
+                            <td>{p.createdAt}</td>
+                            <td>{p.updatedAt}</td>
+                            <td style={{ textAlign: "right" }}>{p.elements}</td>
+                            <td className="actions">
+                                <button className="btn" onClick={() => onEdit(p.id)}>
+                                    Редагувати
+                                </button>
+                                <button className="btn" onClick={() => onClone(p.id)}>
+                                    Клонувати
+                                </button>
+                                <button className="btn" onClick={() => onDelete(p.id)}>
+                                    Видалити
+                                </button>
+                            </td>
+                        </tr>
+                    ))}
+                    {filtered.length === 0 && (
+                        <tr>
+                            <td colSpan="6">Нічого не знайдено</td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+        </Layout>
+    );
+}
+

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -5,6 +5,7 @@ import HomePage from "../pages/HomePage";
 import DailyTasksPage from "../modules/tasks/pages/DailyTasksPage";
 import ResultsPage from "../modules/results/pages/ResultsPage";
 import TemplatesPage from "../modules/templates/pages/TemplatesPage";
+import BusinessProcessesPage from "../modules/processes/pages/BusinessProcessesPage";
 import OrgPage from "../modules/org/pages/OrgPage";
 import TelegramGroupPage from "../modules/telegram/pages/TelegramGroupPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
@@ -58,6 +59,14 @@ export default function AppRouter() {
                     element={
                         <RequireAuth>
                             <DailyTasksPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/business-processes"
+                    element={
+                        <RequireAuth>
+                            <BusinessProcessesPage />
                         </RequireAuth>
                     }
                 />


### PR DESCRIPTION
## Summary
- add Business Processes list page with search, table, and placeholder actions
- wire Business Processes page into router and sidebar navigation

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689a7fe1e7108332904fdd6de6d545a0