### PR TITLE
Improve sidebar, filters and daily tasks date selection

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.css
+++ b/src/components/layout/Sidebar/Sidebar.css
@@ -29,6 +29,7 @@
 .sidebar-content {
     flex: 1;
     overflow-y: auto;
+    overflow-x: hidden;
 }
 
 /* Верхня панель */
@@ -112,17 +113,29 @@
     font-size: var(--fz-sm);
     background: var(--bg);
     color: var(--text);
+    white-space: nowrap;
 }
 
 .submenu {
     list-style: none;
     margin: 0;
-    padding: 0 0 0 25px;
+    padding: 0;
 }
 
 .submenu li a {
     padding: 8px 15px;
     font-size: 12px;
+}
+
+.nav-subitem {
+    display: flex;
+    align-items: center;
+    padding-left: var(--space-3);
+}
+
+.sidebar-divider {
+    border-top: 1px solid var(--border);
+    margin: var(--space-2) 0;
 }
 
 .submenu-arrow {

--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -78,7 +78,7 @@ export default function Sidebar({
                                         <NavLink
                                             to="/results"
                                             className={({ isActive }) =>
-                                                isActive ? "active" : ""
+                                                `${isActive ? "active" : ""} nav-subitem`
                                             }
                                         >
                                             <span className="menu-text">
@@ -90,7 +90,7 @@ export default function Sidebar({
                                         <NavLink
                                             to="/templates"
                                             className={({ isActive }) =>
-                                                isActive ? "active" : ""
+                                                `${isActive ? "active" : ""} nav-subitem`
                                             }
                                         >
                                             <span className="menu-text">
@@ -116,6 +116,7 @@ export default function Sidebar({
                                 )}
                             </NavLink>
                         </li>
+                        <li className="sidebar-divider" aria-hidden="true"></li>
                         <li>
                             <NavLink
                                 to="/business-processes"

--- a/src/modules/results/components/ResultsFilters.css
+++ b/src/modules/results/components/ResultsFilters.css
@@ -19,9 +19,8 @@
   font-size: var(--fz-base); color: var(--text);
 }
 
-.rf-group{ display:flex; gap:10px; flex-wrap:wrap; }
 .rf-field{
-  display:flex; flex-direction:column; gap:6px;
+  display:flex; align-items:center; gap:6px;
   font-size: var(--fz-sm); color: var(--text-muted);
 }
 .rf-field select{

--- a/src/modules/results/components/ResultsFilters.jsx
+++ b/src/modules/results/components/ResultsFilters.jsx
@@ -35,60 +35,58 @@ export default function ResultsFilters({ value, onChange, onReset }) {
           />
         </label>
 
-        <div className="rf-group">
-          <label className="rf-field">
-            <span>Статус</span>
-            <select
-              className="input"
-              value={local.status}
-              onChange={(e) => change({ status: e.target.value })}
-            >
-              <option value="all">Усі</option>
-              <option value="new">Новий</option>
-              <option value="in_progress">В процесі</option>
-              <option value="done">Виконано</option>
-              <option value="postponed">Відкладено</option>
-            </select>
-          </label>
+        <label className="rf-field">
+          <span>Статус</span>
+          <select
+            className="input"
+            value={local.status}
+            onChange={(e) => change({ status: e.target.value })}
+          >
+            <option value="all">Усі</option>
+            <option value="new">Новий</option>
+            <option value="in_progress">В процесі</option>
+            <option value="done">Виконано</option>
+            <option value="postponed">Відкладено</option>
+          </select>
+        </label>
 
-          <label className="rf-field">
-            <span>Шаблони</span>
-            <select
-              className="input"
-              value={local.hasTemplates}
-              onChange={(e) => change({ hasTemplates: e.target.value })}
-            >
-              <option value="any">Неважливо</option>
-              <option value="yes">Є</option>
-              <option value="no">Немає</option>
-            </select>
-          </label>
+        <label className="rf-field">
+          <span>Шаблони</span>
+          <select
+            className="input"
+            value={local.hasTemplates}
+            onChange={(e) => change({ hasTemplates: e.target.value })}
+          >
+            <option value="any">Неважливо</option>
+            <option value="yes">Є</option>
+            <option value="no">Немає</option>
+          </select>
+        </label>
 
-          <label className="rf-field">
-            <span>Активні задачі</span>
-            <select
-              className="input"
-              value={local.hasActiveTasks}
-              onChange={(e) => change({ hasActiveTasks: e.target.value })}
-            >
-              <option value="any">Неважливо</option>
-              <option value="yes">Є активність</option>
-              <option value="no">Нема активності</option>
-            </select>
-          </label>
+        <label className="rf-field">
+          <span>Активні задачі</span>
+          <select
+            className="input"
+            value={local.hasActiveTasks}
+            onChange={(e) => change({ hasActiveTasks: e.target.value })}
+          >
+            <option value="any">Неважливо</option>
+            <option value="yes">Є активність</option>
+            <option value="no">Нема активності</option>
+          </select>
+        </label>
 
-          <label className="rf-field">
-            <span>Подання</span>
-            <select
-              className="input"
-              value={local.view}
-              onChange={(e) => change({ view: e.target.value })}
-            >
-              <option value="list">Список</option>
-              <option value="owner">Групувати за постановником</option>
-            </select>
-          </label>
-        </div>
+        <label className="rf-field">
+          <span>Подання</span>
+          <select
+            className="input"
+            value={local.view}
+            onChange={(e) => change({ view: e.target.value })}
+          >
+            <option value="list">Список</option>
+            <option value="owner">Групувати за постановником</option>
+          </select>
+        </label>
 
         <div className="rf-actions">
           <button className="btn ghost" onClick={() => onReset && onReset()}>Скинути фільтри</button>

--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -20,6 +20,39 @@
   color: var(--text-muted);
 }
 
+.tasks-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.date-trigger {
+  background: transparent;
+  border: 1px dashed var(--blue);
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.date-trigger:hover {
+  background: color-mix(in srgb, var(--blue) 6%, transparent);
+}
+
+.ico-calendar {
+  pointer-events: none;
+}
+
+.date-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
 .tasks-list {
   display: grid;
 }

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Layout from "../../../components/layout/Layout";
 import "./DailyTasksPage.css";
 import "../../templates/components/TemplatesFilters.css";
 import axios from "axios";
 import { API_BASE_URL } from "../../../config";
 import { formatMinutesToHours } from "../../../utils/timeFormatter";
+import { FiCalendar } from "react-icons/fi";
 
 export default function DailyTasksPage() {
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -15,12 +16,12 @@ export default function DailyTasksPage() {
     status: "any",
     priority: "any",
     timer: "any",
-    date: "",
     result: "any",
     assignee: "any",
   });
   const [timers, setTimers] = useState({});
   const [activeTimerId, setActiveTimerId] = useState(null);
+  const dateInputRef = useRef(null);
 
   const formatDateForApi = (date) => date.toISOString().split("T")[0];
 
@@ -68,7 +69,6 @@ export default function DailyTasksPage() {
       status: "any",
       priority: "any",
       timer: "any",
-      date: "",
       result: "any",
       assignee: "any",
     };
@@ -140,11 +140,40 @@ export default function DailyTasksPage() {
     day: "numeric",
   });
 
+  const goPrevDay = () =>
+    setSelectedDate((d) => new Date(d.getTime() - 86400000));
+  const goNextDay = () =>
+    setSelectedDate((d) => new Date(d.getTime() + 86400000));
+  const openDatePicker = () => dateInputRef.current?.showPicker();
+
   return (
     <Layout>
       <div className="page-header">
         <div className="page-header-left">
-          <h1>Мої задачі на {formattedDate}</h1>
+          <h1 className="tasks-title">
+            <button className="btn ghost icon" onClick={goPrevDay}>
+              ←
+            </button>
+            Мої задачі на
+            <button
+              className="date-trigger"
+              onClick={openDatePicker}
+              title="Обрати дату"
+            >
+              {formattedDate}
+              <FiCalendar className="ico-calendar" aria-hidden />
+            </button>
+            <button className="btn ghost icon" onClick={goNextDay}>
+              →
+            </button>
+            <input
+              type="date"
+              ref={dateInputRef}
+              className="date-input"
+              value={formatDateForApi(selectedDate)}
+              onChange={(e) => setSelectedDate(new Date(e.target.value))}
+            />
+          </h1>
           {filters.assignee !== "any" && filters.assignee !== "" && (
             <span className="muted">Виконавець: {filters.assignee}</span>
           )}
@@ -227,15 +256,6 @@ export default function DailyTasksPage() {
                 <option value="yes">є</option>
                 <option value="no">нема</option>
               </select>
-            </label>
-
-            <label className="tf-field">
-              <span>Дата</span>
-              <input
-                type="date"
-                value={filters.date}
-                onChange={(e) => handleFilterChange({ date: e.target.value })}
-              />
             </label>
 
             <label className="tf-field">

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -33,7 +33,12 @@
     /* заголовки */
     --transition: 160ms ease;
 
-    --sidebar-width: 300px;
+    /* spacing */
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 16px;
+
+    --sidebar-width: 200px;
     --sidebar-collapsed: 60px;
     --right-sidebar-width: 300px;
     --header-height: 56px;


### PR DESCRIPTION
## Summary
- Narrow left sidebar with indented subitems and group divider
- Align results filters in a single responsive row
- Move daily task date picker to header with navigation arrows

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689a8240803c83329ea7d53a2dae9268