### PR TITLE
Add business process editor scaffolding

### DIFF
--- a/src/modules/bp/components/BpCanvas.css
+++ b/src/modules/bp/components/BpCanvas.css
@@ -1,0 +1,5 @@
+.bp-canvas {
+    position: relative;
+    overflow: auto;
+    background: var(--bg);
+}

--- a/src/modules/bp/components/BpCanvas.jsx
+++ b/src/modules/bp/components/BpCanvas.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import "./BpCanvas.css";
+
+export default function BpCanvas() {
+    return <div className="bp-canvas">Канвас</div>;
+}

--- a/src/modules/bp/components/BpInspector.css
+++ b/src/modules/bp/components/BpInspector.css
@@ -1,0 +1,6 @@
+.bp-inspector {
+    width: var(--right-sidebar-width);
+    border-left: 1px solid var(--border);
+    background: var(--surface);
+    padding: var(--space-2);
+}

--- a/src/modules/bp/components/BpInspector.jsx
+++ b/src/modules/bp/components/BpInspector.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import "./BpInspector.css";
+
+export default function BpInspector() {
+    return (
+        <aside className="bp-inspector">
+            <p>Інспектор</p>
+        </aside>
+    );
+}

--- a/src/modules/bp/components/BpToolbar.css
+++ b/src/modules/bp/components/BpToolbar.css
@@ -1,0 +1,12 @@
+.bp-toolbar {
+    display: flex;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+}
+
+.bp-toolbar-group {
+    display: flex;
+    gap: var(--space-1);
+}

--- a/src/modules/bp/components/BpToolbar.jsx
+++ b/src/modules/bp/components/BpToolbar.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import "./BpToolbar.css";
+
+export default function BpToolbar() {
+    return (
+        <div className="bp-toolbar">
+            <div className="bp-toolbar-group">
+                <button className="btn">Дія</button>
+                <button className="btn">IF</button>
+                <button className="btn">Розгалуження</button>
+                <button className="btn">Інтеграція</button>
+            </div>
+            <div className="bp-toolbar-group">
+                <button className="btn">Стрілка</button>
+                <button className="btn">Пунктир</button>
+                <button className="btn">Інтеграційна стрілка</button>
+            </div>
+            <div className="bp-toolbar-group">
+                <button className="btn">Zoom +</button>
+                <button className="btn">Zoom -</button>
+                <button className="btn">Fit</button>
+            </div>
+        </div>
+    );
+}

--- a/src/modules/bp/pages/BpEditorPage.css
+++ b/src/modules/bp/pages/BpEditorPage.css
@@ -1,0 +1,15 @@
+.bp-editor-page {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - var(--header-height));
+}
+
+.bp-editor-main {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+.bp-editor-main .bp-canvas {
+    flex: 1;
+}

--- a/src/modules/bp/pages/BpEditorPage.jsx
+++ b/src/modules/bp/pages/BpEditorPage.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import BpToolbar from "../components/BpToolbar";
+import BpCanvas from "../components/BpCanvas";
+import BpInspector from "../components/BpInspector";
+import "./BpEditorPage.css";
+
+export default function BpEditorPage() {
+    const { id } = useParams();
+
+    return (
+        <div className="bp-editor-page">
+            <BpToolbar />
+            <div className="bp-editor-main">
+                <BpCanvas />
+                <BpInspector />
+            </div>
+        </div>
+    );
+}

--- a/src/modules/bp/pages/BpListPage.css
+++ b/src/modules/bp/pages/BpListPage.css
@@ -1,0 +1,35 @@
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.page-header-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.page-header-actions {
+    display: flex;
+    gap: var(--space-2);
+}
+
+.processes-table .actions {
+    display: flex;
+    gap: var(--space-1);
+}
+
+.link-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--blue);
+    cursor: pointer;
+    font: inherit;
+}
+
+.link-btn:hover {
+    text-decoration: underline;
+}

--- a/src/modules/bp/pages/BpListPage.jsx
+++ b/src/modules/bp/pages/BpListPage.jsx
@@ -1,0 +1,121 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Layout from "../../../components/layout/Layout";
+import "./BpListPage.css";
+
+export default function BpListPage() {
+    const navigate = useNavigate();
+    const [query, setQuery] = useState("");
+
+    const processes = [
+        {
+            id: 1,
+            name: "Онбординг співробітника",
+            description: "Послідовність дій для прийому нового працівника",
+            createdAt: "2024-08-01",
+            updatedAt: "2024-09-15",
+            elements: 12,
+        },
+        {
+            id: 2,
+            name: "Закупівлі",
+            description: "Процес придбання обладнання та матеріалів",
+            createdAt: "2024-07-10",
+            updatedAt: "2024-08-20",
+            elements: 8,
+        },
+    ];
+
+    const filtered = processes.filter((p) => {
+        const q = query.toLowerCase();
+        return (
+            p.name.toLowerCase().includes(q) ||
+            p.description.toLowerCase().includes(q)
+        );
+    });
+
+    const onEdit = (id) => {
+        navigate(`/bp/${id}`);
+    };
+
+    const onClone = (id) => {
+        window.alert(`Клонувати процес ${id}`);
+    };
+
+    const onDelete = (id) => {
+        window.alert(`Видалити процес ${id}`);
+    };
+
+    return (
+        <Layout>
+            <div className="page-header">
+                <div className="page-header-left">
+                    <h1>Бізнес-процеси</h1>
+                    <input
+                        type="search"
+                        className="input"
+                        placeholder="Пошук..."
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                    />
+                </div>
+                <div className="page-header-actions">
+                    <button
+                        className="btn primary"
+                        onClick={() => navigate("/bp/new")}
+                    >
+                        Додати процес
+                    </button>
+                </div>
+            </div>
+
+            <table className="table processes-table">
+                <thead>
+                    <tr>
+                        <th>Назва процесу</th>
+                        <th>Короткий опис</th>
+                        <th>Дата створення</th>
+                        <th>Дата останнього редагування</th>
+                        <th style={{ textAlign: "right" }}>Кількість елементів</th>
+                        <th>Дії</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {filtered.map((p) => (
+                        <tr key={p.id} className="row-hover">
+                            <td>
+                                <button
+                                    className="link-btn"
+                                    onClick={() => onEdit(p.id)}
+                                >
+                                    {p.name}
+                                </button>
+                            </td>
+                            <td>{p.description}</td>
+                            <td>{p.createdAt}</td>
+                            <td>{p.updatedAt}</td>
+                            <td style={{ textAlign: "right" }}>{p.elements}</td>
+                            <td className="actions">
+                                <button className="btn" onClick={() => onEdit(p.id)}>
+                                    Редагувати
+                                </button>
+                                <button className="btn" onClick={() => onClone(p.id)}>
+                                    Клонувати
+                                </button>
+                                <button className="btn" onClick={() => onDelete(p.id)}>
+                                    Видалити
+                                </button>
+                            </td>
+                        </tr>
+                    ))}
+                    {filtered.length === 0 && (
+                        <tr>
+                            <td colSpan="6">Нічого не знайдено</td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+        </Layout>
+    );
+}
+

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -6,6 +6,8 @@ import DailyTasksPage from "../modules/tasks/pages/DailyTasksPage";
 import ResultsPage from "../modules/results/pages/ResultsPage";
 import TemplatesPage from "../modules/templates/pages/TemplatesPage";
 import BusinessProcessesPage from "../modules/processes/pages/BusinessProcessesPage";
+import BpListPage from "../modules/bp/pages/BpListPage";
+import BpEditorPage from "../modules/bp/pages/BpEditorPage";
 import OrgPage from "../modules/org/pages/OrgPage";
 import TelegramGroupPage from "../modules/telegram/pages/TelegramGroupPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
@@ -67,6 +69,30 @@ export default function AppRouter() {
                     element={
                         <RequireAuth>
                             <BusinessProcessesPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/bp"
+                    element={
+                        <RequireAuth>
+                            <BpListPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/bp/new"
+                    element={
+                        <RequireAuth>
+                            <BpEditorPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/bp/:id"
+                    element={
+                        <RequireAuth>
+                            <BpEditorPage />
                         </RequireAuth>
                     }
                 />


### PR DESCRIPTION
## Summary
- scaffold business process module with list and editor pages
- add toolbar, canvas, and inspector placeholders
- register /bp routes for list and editor

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689a8487f14483329d0ea818ee437691