### PR TITLE
feat: wrap org page with main layout

### DIFF
--- a/src/modules/org/pages/OrgPage.css
+++ b/src/modules/org/pages/OrgPage.css
@@ -3,18 +3,17 @@
 .org-layout{
   display:grid;
   grid-template-columns: 360px 1fr;
-  gap:0;
-  height:100%;
+  min-height: calc(100dvh - var(--header-h) - var(--footer-h));
 }
 
 .org-left{
   padding:12px;
   border-right:1px solid var(--border);
   background:#fff;
+  overflow:auto;
 }
 
 .org-canvas{
-  position:relative;
   overflow:auto;
   background: var(--bg);
 }

--- a/src/modules/org/pages/OrgPage.jsx
+++ b/src/modules/org/pages/OrgPage.jsx
@@ -67,29 +67,32 @@ export default function OrgPage() {
   );
 
   return (
-    <div className="org-layout">
-      <aside className="org-left card">
-        <OrgLeftPanel
-          positions={filteredPositions}
-          allPositions={positions}
-          filters={filters}
-          onFiltersChange={setFilters}
-          onSearch={handleSearch}
-          onUpdatePosition={handleUpdatePosition}
-        />
-      </aside>
+    <div className="page">
+      <h1 className="page-title">Орг. структура</h1>
+      <div className="org-layout">
+        <aside className="org-left card">
+          <OrgLeftPanel
+            positions={filteredPositions}
+            allPositions={positions}
+            filters={filters}
+            onFiltersChange={setFilters}
+            onSearch={handleSearch}
+            onUpdatePosition={handleUpdatePosition}
+          />
+        </aside>
 
-      <main className="org-canvas">
-        <OrgCanvas
-          tree={tree}
-          expanded={expanded}
-          onToggleExpand={toggleExpand}
-          highlightIds={highlightIds}
-          onUpdateUnit={handleUpdateUnit}
-          onMove={handleMove}
-          onReplaceUser={handleReplaceUser}
-        />
-      </main>
+        <main className="org-canvas">
+          <OrgCanvas
+            tree={tree}
+            expanded={expanded}
+            onToggleExpand={toggleExpand}
+            highlightIds={highlightIds}
+            onUpdateUnit={handleUpdateUnit}
+            onMove={handleMove}
+            onReplaceUser={handleReplaceUser}
+          />
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate, Outlet } from "react-router-dom";
 
 import HomePage from "../pages/HomePage";
 import DailyTasksPage from "../modules/tasks/pages/DailyTasksPage";
@@ -9,6 +9,7 @@ import BusinessProcessesPage from "../modules/processes/pages/BusinessProcessesP
 import BpListPage from "../modules/bp/pages/BpListPage";
 import BpEditorPage from "../modules/bp/pages/BpEditorPage";
 import OrgPage from "../modules/org/pages/OrgPage";
+import Layout from "../components/layout/Layout";
 import TelegramGroupPage from "../modules/telegram/pages/TelegramGroupPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
 import ForgotPasswordPage from "../modules/auth/pages/ForgotPasswordPage";
@@ -96,14 +97,9 @@ export default function AppRouter() {
                         </RequireAuth>
                     }
                 />
-                <Route
-                    path="/org"
-                    element={
-                        <RequireAuth>
-                            <OrgPage />
-                        </RequireAuth>
-                    }
-                />
+                <Route element={<RequireAuth><Layout><Outlet /></Layout></RequireAuth>}>
+                    <Route path="/org" element={<OrgPage />} />
+                </Route>
                 <Route
                     path="/telegram-group"
                     element={


### PR DESCRIPTION
## Summary
- render /org route inside shared layout
- add page container and title for Org page
- adjust org styles for layout-based scrolling

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689a891f7af4833280485d8779ea2587