### PR TITLE
feat: add daily task creation form

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -230,6 +230,24 @@ export function RightSidebar() {
         return () => clearInterval(interval);
     }, []);
 
+    useEffect(() => {
+        const handler = (e) => {
+            const t = e.detail;
+            setTasks((prev) => [
+                ...prev,
+                {
+                    id: t.id,
+                    title: t.title,
+                    type: t.type,
+                    planned: t.expected_time,
+                    status: t.status,
+                },
+            ]);
+        };
+        window.addEventListener("today-task-added", handler);
+        return () => window.removeEventListener("today-task-added", handler);
+    }, []);
+
     const toggleComplete = async (id) => {
         const current = tasks.find((t) => t.id === id);
         const newStatus = current.status === "done" ? "new" : "done";

--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -128,3 +128,26 @@
   margin-top: 20px;
 }
 
+.add-task-form {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 12px;
+  margin-bottom: 16px;
+}
+
+.add-task-form input,
+.add-task-form select {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.add-task-form .title-input {
+  flex: 1;
+}
+
+.add-task-form input.error {
+  border-color: var(--red, #e00);
+}
+

--- a/src/services/api/tasks.js
+++ b/src/services/api/tasks.js
@@ -1,0 +1,8 @@
+import api from "../api";
+
+export const createDailyTask = async (data) =>
+    (await api.post("/tasks/daily", data)).data;
+
+export const getTaskTemplates = async () =>
+    (await api.get("/tasks/templates")).data;
+


### PR DESCRIPTION
## Summary
- add inline form to create daily tasks with type, time, result and template support
- sync newly created task with Today sidebar and show toast
- include small tasks API helpers

## Testing
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a8972ea3c833282e7a09052c89cea