### PR TITLE
Fix JSX structure in OrgPage to resolve build error

### DIFF
--- a/src/modules/org/pages/OrgPage.jsx
+++ b/src/modules/org/pages/OrgPage.jsx
@@ -117,20 +117,17 @@ export default function OrgPage() {
           onFocusPosition={handleFocusPosition}
         />
       </aside>
-
-
-        <main className="org-canvas">
-          <OrgCanvas
-            tree={tree}
-            expanded={expanded}
-            onToggleExpand={toggleExpand}
-            highlightIds={highlightIds}
-            onUpdateUnit={handleUpdateUnit}
-            onMove={handleMove}
-            onReplaceUser={handleReplaceUser}
-          />
-        </main>
-      </div>
+      <main className="org-canvas">
+        <OrgCanvas
+          tree={tree}
+          expanded={expanded}
+          onToggleExpand={toggleExpand}
+          highlightIds={highlightIds}
+          onUpdateUnit={handleUpdateUnit}
+          onMove={handleMove}
+          onReplaceUser={handleReplaceUser}
+        />
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove extraneous closing div from OrgPage and properly wrap `aside` and `main` sections

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a8df08c4883329d3c13c65b1e5174