### PR TITLE
feat(results): inline result creation

### DIFF
--- a/src/modules/results/api/results.js
+++ b/src/modules/results/api/results.js
@@ -9,6 +9,9 @@ export const getResult = async (id) =>
 export const createResult = async (data) =>
     (await api.post("/results", data)).data;
 
+export const createSubresult = async (parentId, data) =>
+    (await api.post(`/results/${parentId}/children`, data)).data;
+
 export const updateResult = async (id, data) =>
     (await api.patch(`/results/${id}`, data)).data;
 

--- a/src/modules/results/pages/ResultsPage.css
+++ b/src/modules/results/pages/ResultsPage.css
@@ -39,3 +39,42 @@
 .results-loader{
   padding:12px 0;
 }
+
+.results-create{
+  padding:16px;
+  display:grid;
+  gap:12px;
+}
+
+.results-create .rc-row{
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+}
+
+.results-create .rc-field{
+  flex:1;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.results-create .rc-check{
+  display:flex;
+  align-items:center;
+  gap:8px;
+}
+
+.results-create .rc-actions{
+  display:flex;
+  gap:12px;
+}
+
+.results-create .field-error{
+  color:var(--critical);
+  font-size:var(--fz-sm);
+}
+
+.results-create .input.error{
+  border-color:var(--critical);
+}

--- a/src/modules/results/pages/ResultsPage.jsx
+++ b/src/modules/results/pages/ResultsPage.jsx
@@ -5,7 +5,10 @@ import {
   getResult,
   deleteResult,
   toggleResultComplete,
+  createResult,
+  createSubresult,
 } from '../api/results';
+import { useAuth } from '../../../context/AuthContext';
 import ResultsFilters from '../components/ResultsFilters.jsx';
 import ResultRow from '../components/ResultRow.jsx';
 import ResultDetails from '../components/ResultDetails.jsx';
@@ -21,12 +24,26 @@ const defaultFilters = {
 };
 
 export default function ResultsPage() {
+  const { user } = useAuth();
   const [list, setList] = useState([]);
   const [filters, setFilters] = useState(defaultFilters);
   const [page, setPage] = useState(1);
   const [pagination, setPagination] = useState({ page: 1, pageCount: 1, totalCount: 0 });
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState(null);
+  const [showForm, setShowForm] = useState(false);
+  const [parentId, setParentId] = useState(null);
+  const [form, setForm] = useState({ title: '', deadline: '', expected: '', urgent: false, assigneeId: '' });
+  const [errors, setErrors] = useState({});
+
+  const mapItem = (r) => ({
+    ...r,
+    expected: r.expected_result || r.expected,
+    dailyTasksCount: r.daily_tasks_count ?? r.tasks_total ?? 0,
+    urgent: r.is_urgent || r.urgent,
+    ownerName: r.owner_name || r.ownerName,
+    assigneeName: r.assignee_name || r.assigneeName,
+  });
 
   useEffect(() => {
     fetchList();
@@ -43,14 +60,7 @@ export default function ResultsPage() {
       if (filters.hasActiveTasks && filters.hasActiveTasks !== 'any') params.hasActiveTasks = filters.hasActiveTasks;
       if (filters.view) params.view = filters.view;
       const data = await getResults(params);
-      const items = (data.items || []).map((r) => ({
-        ...r,
-        expected: r.expected_result || r.expected,
-        dailyTasksCount: r.daily_tasks_count ?? r.tasks_total ?? 0,
-        urgent: r.is_urgent || r.urgent,
-        ownerName: r.owner_name || r.ownerName,
-        assigneeName: r.assignee_name || r.assigneeName,
-      }));
+      const items = (data.items || []).map(mapItem);
       setList(items);
       setPagination(data.pagination || { page, pageCount: 1, totalCount: 0 });
     } finally {
@@ -65,6 +75,54 @@ export default function ResultsPage() {
   const onFiltersReset = () => {
     setFilters(defaultFilters);
     setPage(1);
+  };
+
+  const openForm = (pid = null) => {
+    setParentId(pid);
+    setForm({ title: '', deadline: '', expected: '', urgent: false, assigneeId: '' });
+    setErrors({});
+    setShowForm(true);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const errs = {};
+    if (!form.title) errs.title = 'Обов\'язково';
+    if (!form.deadline) errs.deadline = 'Обов\'язково';
+    if (Object.keys(errs).length) {
+      setErrors(errs);
+      return;
+    }
+    const payload = {
+      title: form.title,
+      deadline: form.deadline,
+      expected_result: form.expected || undefined,
+      is_urgent: form.urgent,
+    };
+    if (form.assigneeId) payload.assignee_id = form.assigneeId;
+    try {
+      const data = parentId
+        ? await createSubresult(parentId, payload)
+        : await createResult(payload);
+      const mapped = mapItem(data);
+      if (parentId) {
+        setList((prev) =>
+          prev.map((r) =>
+            r.id === parentId
+              ? { ...r, subtasks: [mapped, ...(r.subtasks || [])] }
+              : r
+          )
+        );
+      } else {
+        setList((prev) => [mapped, ...prev]);
+      }
+      setShowForm(false);
+      setParentId(null);
+      alert('Створено');
+    } catch (e) {
+      const apiErrors = e.response?.data?.errors || {};
+      setErrors(apiErrors);
+    }
   };
 
   const toggleExpand = async (id) => {
@@ -133,7 +191,7 @@ export default function ResultsPage() {
         {expanded === r.id && (
           <ResultDetails
             result={r}
-            onAddSubresult={() => {}}
+            onAddSubresult={openForm}
             onCreateTemplate={() => {}}
             onCreateTask={() => {}}
           />
@@ -161,16 +219,92 @@ export default function ResultsPage() {
       <div className="results-page">
         <div className="results-page__header">
           <h1>Результати</h1>
-          <button className="btn primary" onClick={() => (window.location.href = '/results/new')}>
-            Додати результат
+          <button
+            className="btn primary"
+            onClick={() => (showForm ? (setShowForm(false), setParentId(null)) : openForm(null))}
+          >
+            {showForm ? 'Скасувати' : 'Додати результат'}
           </button>
         </div>
 
         <ResultsFilters value={filters} onChange={onFiltersChange} onReset={onFiltersReset} />
 
+        {showForm && (
+          <div className="results-create card">
+            <form onSubmit={handleSubmit}>
+              <div className="rc-row">
+                <label className="rc-field">
+                  <span>Назва*</span>
+                  <input
+                    type="text"
+                    className={`input ${errors.title ? 'error' : ''}`}
+                    value={form.title}
+                    onChange={(e) => setForm({ ...form, title: e.target.value })}
+                  />
+                  {errors.title && <div className="field-error">{errors.title}</div>}
+                </label>
+                <label className="rc-field">
+                  <span>Дедлайн*</span>
+                  <input
+                    type="date"
+                    className={`input ${errors.deadline ? 'error' : ''}`}
+                    value={form.deadline}
+                    onChange={(e) => setForm({ ...form, deadline: e.target.value })}
+                  />
+                  {errors.deadline && <div className="field-error">{errors.deadline}</div>}
+                </label>
+              </div>
+              <label className="rc-field">
+                <span>Очікуваний результат</span>
+                <input
+                  type="text"
+                  className="input"
+                  value={form.expected}
+                  onChange={(e) => setForm({ ...form, expected: e.target.value })}
+                />
+              </label>
+              <label className="rc-check">
+                <input
+                  type="checkbox"
+                  checked={form.urgent}
+                  onChange={(e) => setForm({ ...form, urgent: e.target.checked })}
+                />
+                <span>Терміновість</span>
+              </label>
+              <label className="rc-field">
+                <span>Постановник</span>
+                <input type="text" className="input" value={user?.name || user?.username || ''} readOnly />
+              </label>
+              <label className="rc-field">
+                <span>Відповідальний</span>
+                <input
+                  type="text"
+                  className="input"
+                  value={form.assigneeId}
+                  onChange={(e) => setForm({ ...form, assigneeId: e.target.value })}
+                  placeholder="ID користувача"
+                />
+              </label>
+              <div className="rc-actions">
+                <button type="submit" className="btn primary">Зберегти</button>
+                <button
+                  type="button"
+                  className="btn ghost"
+                  onClick={() => {
+                    setShowForm(false);
+                    setParentId(null);
+                  }}
+                >
+                  Скасувати
+                </button>
+              </div>
+            </form>
+          </div>
+        )}
+
         {loading && <div className="results-loader">Завантаження…</div>}
 
-        {!loading && list.length === 0 && <ResultsEmpty onCreate={() => (window.location.href = '/results/new')} />}
+        {!loading && list.length === 0 && <ResultsEmpty onCreate={() => openForm(null)} />}
 
         {!loading && list.length > 0 && (
           <div className="results-list">


### PR DESCRIPTION
## Summary
- add API method to create subresults
- add inline form for creating results or subresults
- style inline creation form

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a895723808332b9d9aca528acad5a