### PR TITLE
feat: add active company selection

### DIFF
--- a/src/components/layout/Header/Header.jsx
+++ b/src/components/layout/Header/Header.jsx
@@ -2,10 +2,11 @@ import React, { useState } from "react";
 import "./Header.css";
 import { FiMenu, FiSearch, FiCheckSquare } from "react-icons/fi";
 import { useAuth } from "../../../context/AuthContext";
+import UserMenu from "../UserMenu/UserMenu";
 
 export default function Header() {
     const [userMenuOpen, setUserMenuOpen] = useState(false);
-    const { user, logout } = useAuth();
+    const { user } = useAuth();
 
     const handleLeftToggle = () => {
         window.dispatchEvent(new CustomEvent("ui:toggleLeftSidebar"));
@@ -63,17 +64,7 @@ export default function Header() {
                 >
                     {initials}
                 </div>
-                {userMenuOpen && (
-                    <div className="user-dropdown">
-                        <ul>
-                            <li>Профіль</li>
-                            <li>Налаштування</li>
-                            <li className="logout" onClick={logout}>
-                                Вихід
-                            </li>
-                        </ul>
-                    </div>
-                )}
+                {userMenuOpen && <UserMenu />}
             </div>
         </header>
     );

--- a/src/components/layout/Sidebar/Sidebar.css
+++ b/src/components/layout/Sidebar/Sidebar.css
@@ -147,6 +147,13 @@
     transform: rotate(180deg);
 }
 
+/* Активна компанія внизу сайдбару */
+.active-company {
+    padding: 10px 15px;
+    border-top: 1px solid var(--border);
+    font-size: 13px;
+}
+
 /* Right sidebar */
 .right-sidebar {
     width: var(--right-sidebar-width);

--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -19,6 +19,7 @@ import {
 import CheckToggle from "../../ui/CheckToggle";
 import axios from "axios";
 import { API_BASE_URL } from "../../../config";
+import { useCompany } from "../../../context/CompanyContext";
 
 export default function Sidebar({
     isOpen,
@@ -29,6 +30,7 @@ export default function Sidebar({
     const [isResultsOpen, setIsResultsOpen] = useState(true);
     const location = useLocation();
     const resultsActive = location.pathname.startsWith("/results");
+    const { activeCompany } = useCompany();
 
     return (
         <aside className={`sidebar ${isOpen ? "expanded" : "collapsed"}`}>
@@ -184,6 +186,9 @@ export default function Sidebar({
                         </li>
                     </ul>
                 </nav>
+            </div>
+            <div className="active-company">
+                {activeCompany?.name || "Компанія не вибрана"}
             </div>
         </aside>
     );

--- a/src/components/layout/UserMenu/UserMenu.css
+++ b/src/components/layout/UserMenu/UserMenu.css
@@ -1,0 +1,10 @@
+.company-select-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.company-select {
+    width: 100%;
+    padding: 4px;
+}

--- a/src/components/layout/UserMenu/UserMenu.jsx
+++ b/src/components/layout/UserMenu/UserMenu.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import "./UserMenu.css";
+import { useAuth } from "../../../context/AuthContext";
+import { useCompany } from "../../../context/CompanyContext";
+
+export default function UserMenu() {
+    const { user, logout } = useAuth();
+    const { activeCompany, setActiveCompany } = useCompany();
+    const companies = user?.companies || [];
+
+    const handleChange = (e) => {
+        const company = companies.find(
+            (c) => String(c.id) === e.target.value
+        );
+        setActiveCompany(company || null);
+    };
+
+    return (
+        <div className="user-dropdown">
+            <ul>
+                <li>Профіль</li>
+                <li>Налаштування</li>
+                <li className="company-select-item">
+                    <span>Компанія</span>
+                    <select
+                        className="company-select"
+                        value={activeCompany?.id || ""}
+                        onChange={handleChange}
+                    >
+                        <option value="">Не вибрана</option>
+                        {companies.map((c) => (
+                            <option key={c.id} value={c.id}>
+                                {c.name}
+                            </option>
+                        ))}
+                    </select>
+                </li>
+                <li className="logout" onClick={logout}>
+                    Вихід
+                </li>
+            </ul>
+        </div>
+    );
+}

--- a/src/context/CompanyContext.js
+++ b/src/context/CompanyContext.js
@@ -1,0 +1,15 @@
+import React, { createContext, useContext, useState } from "react";
+
+const CompanyContext = createContext(null);
+
+export function CompanyProvider({ children }) {
+    const [activeCompany, setActiveCompany] = useState(null);
+
+    return (
+        <CompanyContext.Provider value={{ activeCompany, setActiveCompany }}>
+            {children}
+        </CompanyContext.Provider>
+    );
+}
+
+export const useCompany = () => useContext(CompanyContext);

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,13 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/global.css";
 import { AuthProvider } from "./context/AuthContext";
+import { CompanyProvider } from "./context/CompanyContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
     <AuthProvider>
-        <App />
+        <CompanyProvider>
+            <App />
+        </CompanyProvider>
     </AuthProvider>
 );


### PR DESCRIPTION
## Summary
- add CompanyContext for global active company state
- show active company name at bottom of sidebar
- add user menu dropdown to switch active company

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689b16a86f94833290a92722b1c6eb20