### PR TITLE
fix: remove duplicate nav click handler

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -38,12 +38,6 @@ export default function Sidebar({
         }
     };
 
-    const handleNavClick = () => {
-        if (isOpen) {
-            onToggle();
-        }
-    };
-
     return (
         <aside className={`sidebar ${isOpen ? "expanded" : "collapsed"}`}>
             <div className="sidebar-content">


### PR DESCRIPTION
## Summary
- remove duplicate handleNavClick function in Sidebar

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689b1c12852883329b29040b45630aff