### PR TITLE
feat: refresh results creation form with user selector

### DIFF
--- a/src/modules/results/pages/ResultsPage.css
+++ b/src/modules/results/pages/ResultsPage.css
@@ -78,3 +78,8 @@
 .results-create .input.error{
   border-color:var(--critical);
 }
+
+.results-create textarea{
+  min-height:200px;
+  resize:vertical;
+}

--- a/src/services/api/users.js
+++ b/src/services/api/users.js
@@ -1,0 +1,3 @@
+import api from "../api";
+
+export const getUsers = async () => (await api.get("/users")).data;


### PR DESCRIPTION
## Summary
- hide add result button when form active and reset after save
- add description textarea and final result with urgent checkbox
- load users list for responsible select via new API

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1ec408188332bd5a0353df0cfec0