### PR TITLE
feat: group tasks menu

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.css
+++ b/src/components/layout/Sidebar/Sidebar.css
@@ -133,6 +133,12 @@
     padding-left: var(--space-3);
 }
 
+.submenu-icon {
+    font-size: 16px;
+    margin-right: 8px;
+    min-width: 18px;
+}
+
 .sidebar-divider {
     border-top: 1px solid var(--border);
     margin: var(--space-2) 0;

--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -27,9 +27,12 @@ export default function Sidebar({
     resultsCount = 0,
     telegramCount = 0,
 }) {
-    const [isResultsOpen, setIsResultsOpen] = useState(true);
+    const [isTasksOpen, setIsTasksOpen] = useState(true);
     const location = useLocation();
-    const resultsActive = location.pathname.startsWith("/results");
+    const tasksActive =
+        location.pathname.startsWith("/results") ||
+        location.pathname.startsWith("/templates") ||
+        location.pathname.startsWith("/tasks");
     const { activeCompany } = useCompany();
 
     const handleNavClick = () => {
@@ -61,26 +64,25 @@ export default function Sidebar({
                 {/* Пункти меню */}
                 <nav>
                     <ul>
-                        <li className={resultsActive ? "active" : ""}>
+                        <li className={tasksActive ? "active" : ""}>
                             <button
                                 className="menu-link"
-                                onClick={() => setIsResultsOpen(!isResultsOpen)}
-                                aria-expanded={isResultsOpen}
+                                onClick={() => setIsTasksOpen(!isTasksOpen)}
+                                aria-expanded={isTasksOpen}
                             >
-                                <FiBarChart2 className="menu-icon" />
+                                <FiCheckSquare className="menu-icon" />
                                 {isOpen && (
                                     <>
-                                        <span className="menu-text">Результати</span>
-                                        <span className="badge menu-badge">{resultsCount}</span>
+                                        <span className="menu-text">Задачі</span>
                                         <FiChevronDown
                                             className={`submenu-arrow ${
-                                                isResultsOpen ? "open" : ""
+                                                isTasksOpen ? "open" : ""
                                             }`}
                                         />
                                     </>
                                 )}
                             </button>
-                            {isOpen && isResultsOpen && (
+                            {isOpen && isTasksOpen && (
                                 <ul className="submenu">
                                     <li>
                                         <NavLink
@@ -90,9 +92,11 @@ export default function Sidebar({
                                             }
                                             onClick={handleNavClick}
                                         >
+                                            <FiBarChart2 className="submenu-icon" />
                                             <span className="menu-text">
                                                 Результати
                                             </span>
+                                            <span className="badge menu-badge">{resultsCount}</span>
                                         </NavLink>
                                     </li>
                                     <li>
@@ -103,29 +107,28 @@ export default function Sidebar({
                                             }
                                             onClick={handleNavClick}
                                         >
+                                            <FiGrid className="submenu-icon" />
                                             <span className="menu-text">
                                                 Шаблони
                                             </span>
                                         </NavLink>
                                     </li>
+                                    <li>
+                                        <NavLink
+                                            to="/tasks"
+                                            className={({ isActive }) =>
+                                                `${isActive ? "active" : ""} nav-subitem`
+                                            }
+                                            onClick={handleNavClick}
+                                        >
+                                            <FiCheckSquare className="submenu-icon" />
+                                            <span className="menu-text">
+                                                Щоденні задачі
+                                            </span>
+                                        </NavLink>
+                                    </li>
                                 </ul>
                             )}
-                        </li>
-                        <li>
-                            <NavLink
-                                to="/tasks"
-                                className={({ isActive }) =>
-                                    isActive ? "active" : ""
-                                }
-                                onClick={handleNavClick}
-                            >
-                                <FiCheckSquare className="menu-icon" />
-                                {isOpen && (
-                                    <span className="menu-text">
-                                        Щоденні задачі
-                                    </span>
-                                )}
-                            </NavLink>
                         </li>
                         <li className="sidebar-divider" aria-hidden="true"></li>
                         <li>


### PR DESCRIPTION
## Summary
- group tasks-related navigation into a single collapsible item
- add icons and active link handling for task subitems

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689b2237adb48332bdf9244a2b022558