### PR TITLE
fix: make header fixed

### DIFF
--- a/src/components/layout/Header/Header.css
+++ b/src/components/layout/Header/Header.css
@@ -6,9 +6,11 @@
     align-items: center;
     justify-content: space-between;
     padding: 0 20px;
-    position: sticky;
+    position: fixed;
     top: 0;
-    z-index: 10;
+    left: calc(var(--left-open) * var(--sidebar-width));
+    right: calc(var(--right-open) * var(--right-sidebar-width));
+    z-index: 120;
     border-bottom: 1px solid var(--border);
 }
 

--- a/src/components/layout/Layout.css
+++ b/src/components/layout/Layout.css
@@ -18,7 +18,9 @@
 .layout-column {
     display: flex;
     flex-direction: column;
-    min-height: 100vh;
+    height: 100vh;
+    box-sizing: border-box;
+    padding-top: var(--header-height);
     margin-left: calc(var(--left-open) * var(--sidebar-width));
     margin-right: calc(var(--right-open) * var(--right-sidebar-width));
     transition: margin var(--transition);


### PR DESCRIPTION
## Summary
- keep header fixed at top with responsive offsets for sidebars
- shift main layout to account for fixed header height

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b28f4482c8332b7a210270b1a9c04