### PR TITLE
feat: integrate api client and result checkbox

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -17,8 +17,7 @@ import {
     FiGitBranch,
 } from "react-icons/fi";
 import CheckToggle from "../../ui/CheckToggle";
-import axios from "axios";
-import { API_BASE_URL } from "../../../config";
+import api from "../../../services/api";
 import { useCompany } from "../../../context/CompanyContext";
 
 export default function Sidebar({
@@ -278,9 +277,10 @@ export function RightSidebar() {
             )
         );
         try {
-            await axios.patch(
-                `${API_BASE_URL}/task/update-field?id=${id}`,
-                { field: "status", value: newStatus }
+            await api.patch(
+                "/task/update-field",
+                { field: "status", value: newStatus },
+                { params: { id } }
             );
         } catch (e) {
             setTasks((prev) =>

--- a/src/modules/auth/pages/ForgotPasswordPage.jsx
+++ b/src/modules/auth/pages/ForgotPasswordPage.jsx
@@ -1,8 +1,7 @@
 // frontend/src/modules/auth/pages/ForgotPasswordPage.jsx
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import axios from "axios";
-import { API_BASE_URL } from "../../../config";
+import api from "../../../services/api";
 import AuthLayout from "../../../components/layout/AuthLayout/AuthLayout";
 import "./LoginPage.css";
 
@@ -16,8 +15,8 @@ export default function ForgotPasswordPage() {
         setError("");
         setMessage("");
         try {
-            const res = await axios.post(
-                `${API_BASE_URL}/auth/request-password-reset`,
+            const res = await api.post(
+                "/auth/request-password-reset",
                 { email }
             );
             if (res.data && res.data.success) {

--- a/src/modules/auth/pages/ResetPasswordPage.jsx
+++ b/src/modules/auth/pages/ResetPasswordPage.jsx
@@ -1,8 +1,7 @@
 // frontend/src/modules/auth/pages/ResetPasswordPage.jsx
 import React, { useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import axios from "axios";
-import { API_BASE_URL } from "../../../config";
+import api from "../../../services/api";
 import AuthLayout from "../../../components/layout/AuthLayout/AuthLayout";
 import "./LoginPage.css";
 
@@ -17,8 +16,8 @@ export default function ResetPasswordPage() {
         setError("");
         setMessage("");
         try {
-            const res = await axios.post(
-                `${API_BASE_URL}/auth/reset-password`,
+            const res = await api.post(
+                "/auth/reset-password",
                 { token, password }
             );
             if (res.data && res.data.success) {

--- a/src/modules/orgStructure/pages/OrgStructurePage.jsx
+++ b/src/modules/orgStructure/pages/OrgStructurePage.jsx
@@ -1,8 +1,7 @@
 // frontend/src/modules/org/pages/OrgStructurePage.jsx
 import React, { useEffect, useState } from "react";
 import Layout from "../../../components/layout/Layout";
-import axios from "axios";
-import { API_BASE_URL } from "../../../config";
+import api from "../../../services/api";
 
 export default function OrgStructurePage() {
     const [tree, setTree] = useState([]);
@@ -11,8 +10,8 @@ export default function OrgStructurePage() {
         async function load() {
             try {
                 const [posRes, userRes] = await Promise.all([
-                    axios.get(`${API_BASE_URL}/position`),
-                    axios.get(`${API_BASE_URL}/user`),
+                    api.get("/position"),
+                    api.get("/user"),
                 ]);
                 const positions = posRes.data;
                 const users = userRes.data;

--- a/src/modules/results/api/results.js
+++ b/src/modules/results/api/results.js
@@ -18,5 +18,5 @@ export const updateResult = async (id, data) =>
 export const deleteResult = async (id) =>
     (await api.delete(`/results/${id}`)).data;
 
-export const toggleResultComplete = async (id, isCompleted) =>
-    (await api.post(`/results/${id}/complete`, { is_completed: isCompleted })).data;
+export const toggleResultComplete = async (id, done) =>
+    (await api.patch(`/results/${id}`, { done })).data;

--- a/src/modules/results/components/ResultRow.css
+++ b/src/modules/results/components/ResultRow.css
@@ -35,6 +35,20 @@
   white-space:nowrap;
 }
 
+.result-row.is-done{
+  color: var(--text-muted);
+}
+.result-row.is-done .title{
+  text-decoration: line-through;
+  color: var(--text-muted);
+}
+
+.result-row .actions .done-label{
+  display:flex;
+  align-items:center;
+  gap:4px;
+}
+
 .result-row .actions .btn{
   width:auto;
   white-space:nowrap;

--- a/src/modules/results/components/ResultRow.jsx
+++ b/src/modules/results/components/ResultRow.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import "./ResultRow.css";
+import CheckToggle from "../../../components/ui/CheckToggle";
 
 /**
  * result: {
@@ -15,15 +16,17 @@ import "./ResultRow.css";
  * onEdit(id)
  * onArchive(id)
  * onDelete(id)  // має перевіряти права вище
- * onMarkDone(id) // підтвердження робити вище
- */
+ * onToggleDone(id, done)
+*/
 export default function ResultRow({
   result, expanded,
-  onToggleExpand, onCreateTemplate, onCreateTask, onViewTasks, onEdit, onArchive, onDelete, onMarkDone
+  onToggleExpand, onCreateTemplate, onCreateTask, onViewTasks, onEdit, onArchive, onDelete, onToggleDone
 }) {
   const statusClass = mapStatus(result.status);
+  const isDone = Boolean(result.done || result.completed_at);
+  const rowClass = `result-row ${expanded ? "expanded" : ""} ${isDone ? "is-done" : ""}`;
   return (
-    <div className={`result-row ${expanded ? "expanded" : ""}`}>
+    <div className={rowClass}>
       <button className="caret" aria-label="Розгорнути" onClick={() => onToggleExpand && onToggleExpand(result.id)}>
         {expanded ? "▾" : "▸"}
       </button>
@@ -51,7 +54,14 @@ export default function ResultRow({
         {onDelete && (
           <button className="btn ghost" onClick={() => onDelete(result.id)}>Видалити</button>
         )}
-        <button className="btn primary" onClick={() => onMarkDone && onMarkDone(result.id)}>Позначити виконаним</button>
+        <label className="done-label">
+          <CheckToggle
+            checked={isDone}
+            onChange={() => onToggleDone && onToggleDone(result.id, !isDone)}
+            ariaLabel="Готово"
+          />
+          <span className="done-text">Готово</span>
+        </label>
       </div>
     </div>
   );

--- a/src/modules/results/pages/ResultsPage.jsx
+++ b/src/modules/results/pages/ResultsPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Layout from '../../../components/layout/Layout.jsx';
-import { getResults } from '../api/results';
+import { getResults, toggleResultComplete } from '../api/results';
 import ResultRow from '../components/ResultRow.jsx';
 import ResultDetails from '../components/ResultDetails.jsx';
 import ResultsEmpty from '../components/ResultsEmpty.jsx';
@@ -37,6 +37,22 @@ export default function ResultsPage() {
     setExpanded((prev) => (prev === id ? null : id));
   };
 
+  const handleToggleDone = async (id, done) => {
+    const prevDone = results.find((r) => r.id === id)?.done;
+    setResults((prev) => prev.map((r) => (r.id === id ? { ...r, done } : r)));
+    try {
+      await toggleResultComplete(id, done);
+    } catch (e) {
+      setResults((prev) =>
+        prev.map((r) => (r.id === id ? { ...r, done: prevDone } : r))
+      );
+      const msg = e.response?.data?.message || 'Не вдалося зберегти';
+      window.dispatchEvent(
+        new CustomEvent('toast', { detail: { type: 'error', message: msg } })
+      );
+    }
+  };
+
   return (
     <Layout>
       <div className="results-page">
@@ -68,6 +84,7 @@ export default function ResultsPage() {
                   result={r}
                   expanded={expanded === r.id}
                   onToggleExpand={toggleExpand}
+                  onToggleDone={handleToggleDone}
                 />
                 {expanded === r.id && <ResultDetails result={r} />}
               </React.Fragment>


### PR DESCRIPTION
## Summary
- replace direct axios usage with centralized API client across pages
- add completion checkbox in result rows with optimistic PATCH update

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689b2f7f8c388332be5fbc53cb4152de