### PR TITLE
feat: add basic swimlane editor

### DIFF
--- a/src/modules/bp/components/BpCanvas.css
+++ b/src/modules/bp/components/BpCanvas.css
@@ -2,4 +2,28 @@
     position: relative;
     overflow: auto;
     background: var(--bg);
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+    padding: 8px;
+}
+
+.bp-lane {
+    background: var(--bg-light, #fff);
+    border: 1px solid var(--border, #ccc);
+    padding: 8px;
+    min-width: 160px;
+}
+
+.bp-lane-title {
+    width: 100%;
+    font-weight: 600;
+    border: none;
+    background: transparent;
+    outline: none;
+}
+
+.bp-add-lane {
+    align-self: stretch;
+    padding: 8px 12px;
 }

--- a/src/modules/bp/components/BpCanvas.jsx
+++ b/src/modules/bp/components/BpCanvas.jsx
@@ -1,6 +1,33 @@
-import React from "react";
+import React, { useState } from "react";
 import "./BpCanvas.css";
 
 export default function BpCanvas() {
-    return <div className="bp-canvas">Канвас</div>;
+    const [lanes, setLanes] = useState([]);
+
+    const addLane = () => {
+        const id = crypto.randomUUID();
+        setLanes([...lanes, { id, title: "" }]);
+    };
+
+    const updateLaneTitle = (id, title) => {
+        setLanes(lanes.map((l) => (l.id === id ? { ...l, title } : l)));
+    };
+
+    return (
+        <div className="bp-canvas">
+            {lanes.map((lane) => (
+                <div key={lane.id} className="bp-lane">
+                    <input
+                        className="bp-lane-title"
+                        value={lane.title}
+                        placeholder="Назва посади"
+                        onChange={(e) => updateLaneTitle(lane.id, e.target.value)}
+                    />
+                </div>
+            ))}
+            <button className="bp-add-lane" onClick={addLane}>
+                + Додати свімлейн
+            </button>
+        </div>
+    );
 }


### PR DESCRIPTION
## Summary
- implement minimal swimlane structure with add and rename
- style canvas to display swimlanes as columns

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689b40dbf1588332af846d6d5abc2511