### PR TITLE
feat: add due date field to result form

### DIFF
--- a/src/modules/results/components/AddResultForm.css
+++ b/src/modules/results/components/AddResultForm.css
@@ -7,9 +7,20 @@
 }
 
 .add-result-form .arf-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
   gap: 12px;
-  align-items: flex-end;
+  align-items: end;
+}
+
+@media (max-width: 640px) {
+  .add-result-form .arf-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .add-result-form .arf-check {
+    grid-column: 1 / -1;
+  }
 }
 
 .add-result-form .arf-field {
@@ -23,6 +34,15 @@
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.add-result-form .arf-hint {
+  font-size: var(--fz-sm);
+  color: var(--text-muted);
+}
+
+.add-result-form .input.invalid {
+  border-color: var(--critical);
 }
 
 .add-result-form textarea {

--- a/src/modules/results/components/AddResultForm.jsx
+++ b/src/modules/results/components/AddResultForm.jsx
@@ -6,12 +6,14 @@ export default function AddResultForm({ onSaved, onCancel }) {
   const [form, setForm] = useState({
     title: '',
     final_result: '',
+    due_date: '',
     urgent: false,
     description: '',
     responsible_id: ''
   });
   const [users, setUsers] = useState([]);
   const [error, setError] = useState('');
+  const [dueDateValid, setDueDateValid] = useState(true);
 
   useEffect(() => {
     const loadUsers = async () => {
@@ -27,7 +29,12 @@ export default function AddResultForm({ onSaved, onCancel }) {
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
-    setForm((prev) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
+    const val = type === 'checkbox' ? checked : value;
+    setForm((prev) => ({ ...prev, [name]: val }));
+    if (name === 'due_date') {
+      const re = /^\d{2}\.\d{2}\.\d{4} \d{2}:\d{2}$/;
+      setDueDateValid(re.test(val) || val === '');
+    }
   };
 
   const handleSubmit = async (e) => {
@@ -37,13 +44,15 @@ export default function AddResultForm({ onSaved, onCancel }) {
       const payload = {
         title: form.title,
         final_result: form.final_result,
+        due_date: form.due_date,
         urgent: form.urgent,
         description: form.description,
         responsible_id: Number(form.responsible_id)
       };
       await api.post('/results', payload);
       onSaved && onSaved();
-      setForm({ title: '', final_result: '', urgent: false, description: '', responsible_id: '' });
+      setForm({ title: '', final_result: '', due_date: '', urgent: false, description: '', responsible_id: '' });
+      setDueDateValid(true);
     } catch (e) {
       const msg = e.response?.data?.message || 'Не вдалося створити результат';
       setError(msg);
@@ -83,6 +92,20 @@ export default function AddResultForm({ onSaved, onCancel }) {
               onChange={handleChange}
               required
             />
+          </label>
+          <label className="arf-field">
+            <span>Кінцевий термін</span>
+            <input
+              type="text"
+              name="due_date"
+              className={`input${!dueDateValid && form.due_date ? ' invalid' : ''}`}
+              placeholder="ДД.ММ.РРРР гг:хх"
+              value={form.due_date}
+              onChange={handleChange}
+            />
+            {!dueDateValid && form.due_date && (
+              <span className="arf-hint">Формат: ДД.ММ.РРРР гг:хх</span>
+            )}
           </label>
           <label className="arf-check">
             <input


### PR DESCRIPTION
## Summary
- add optional due date field to result creation form with regex hint
- update layout to grid with responsive two-column fallback

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e046099248332839a0a8373990aff