### PR TITLE
feat: add due date to result payload

### DIFF
--- a/src/modules/results/components/AddResultForm.jsx
+++ b/src/modules/results/components/AddResultForm.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { format } from 'date-fns';
 import api from '../../../services/api';
 import './AddResultForm.css';
 
@@ -8,7 +9,8 @@ export default function AddResultForm({ onSaved, onCancel }) {
     final_result: '',
     urgent: false,
     description: '',
-    responsible_id: ''
+    responsible_id: '',
+    due_date: ''
   });
   const [users, setUsers] = useState([]);
   const [error, setError] = useState('');
@@ -41,9 +43,14 @@ export default function AddResultForm({ onSaved, onCancel }) {
         description: form.description,
         responsible_id: Number(form.responsible_id)
       };
+
+      if (form.due_date) {
+        payload.due_date = format(new Date(form.due_date), 'dd.MM.yyyy HH:mm');
+      }
+
       await api.post('/results', payload);
       onSaved && onSaved();
-      setForm({ title: '', final_result: '', urgent: false, description: '', responsible_id: '' });
+      setForm({ title: '', final_result: '', urgent: false, description: '', responsible_id: '', due_date: '' });
     } catch (e) {
       const msg = e.response?.data?.message || 'Не вдалося створити результат';
       setError(msg);
@@ -94,6 +101,17 @@ export default function AddResultForm({ onSaved, onCancel }) {
             <span>Терміново</span>
           </label>
         </div>
+
+        <label className="arf-field">
+          <span>Дедлайн</span>
+          <input
+            type="datetime-local"
+            name="due_date"
+            className="input"
+            value={form.due_date}
+            onChange={handleChange}
+          />
+        </label>
 
         <label className="arf-field">
           <span>Опис</span>


### PR DESCRIPTION
## Summary
- capture optional result due date and include it in API payload

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689e04b0c3748332b958c597f57cdc2a