### PR TITLE
Align result form buttons and mobile layout

### DIFF
--- a/src/modules/results/components/AddResultForm.css
+++ b/src/modules/results/components/AddResultForm.css
@@ -53,9 +53,25 @@
 .add-result-form .arf-actions {
   display: flex;
   gap: 12px;
+  justify-content: flex-end;
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid transparent;
+}
+
+@media (max-width: 576px) {
+  .add-result-form .arf-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .add-result-form .arf-actions .btn {
+    width: 100%;
+  }
 }
 
 .add-result-form .arf-error {
   color: var(--critical);
   font-size: var(--fz-sm);
+  min-height: var(--space-3);
 }

--- a/src/modules/results/components/AddResultForm.jsx
+++ b/src/modules/results/components/AddResultForm.jsx
@@ -144,7 +144,7 @@ export default function AddResultForm({ onSaved, onCancel }) {
           </select>
         </label>
 
-        {error && <div className="arf-error">{error}</div>}
+        <div className="arf-error" aria-live="polite">{error}</div>
 
         <div className="arf-actions">
           <button type="submit" className="btn primary">Зберегти</button>


### PR DESCRIPTION
## Summary
- Right-align result form action buttons and add footer spacing
- Stack full-width buttons on mobile and reserve error space to prevent layout jumps

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689e0fb530748332bc6982b234a5f03d