### PR TITLE
feat(results): add date picker

### DIFF
--- a/src/modules/results/components/AddResultForm.css
+++ b/src/modules/results/components/AddResultForm.css
@@ -8,7 +8,7 @@
 
 .add-result-form .arf-row {
   display: grid;
-  grid-template-columns: 1fr 1fr auto;
+  grid-template-columns: 1fr 1fr 1fr auto;
   gap: 12px;
   align-items: end;
 }
@@ -19,6 +19,10 @@
   }
 
   .add-result-form .arf-check {
+    grid-column: 1 / -1;
+  }
+
+  .add-result-form .arf-due {
     grid-column: 1 / -1;
   }
 }


### PR DESCRIPTION
## Summary
- allow selecting a calendar date alongside due time
- validate date not being in the past and send with result payload
- expand result form layout for new date field

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689e0ff1df288332a77c4366513ef415