### PR TITLE
style: dim completed results

### DIFF
--- a/src/modules/results/components/ResultRow.css
+++ b/src/modules/results/components/ResultRow.css
@@ -8,23 +8,42 @@
   padding:12px;
   border-bottom:1px solid var(--border);
   background:#fff;
+  transition: var(--transition);
 }
 .result-row:hover{ box-shadow: var(--shadow); }
+
+.result-row.done{
+  opacity:0.6;
+  color:var(--text-muted);
+}
+.result-row.done:hover{ box-shadow: var(--shadow-sm); }
+.result-row.done .title{
+  color:var(--text-muted);
+  text-decoration:line-through;
+}
+.result-row.done .meta,
+.result-row.done .meta .v,
+.result-row.done .expected{
+  color:var(--text-muted);
+}
 
 .result-row .caret{
   border:1px solid var(--border); background:#fff; border-radius:8px; width:28px; height:28px; cursor:pointer;
 }
 .result-row .title{
   font-weight:600; color:var(--navy); text-decoration:none; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+  transition: var(--transition);
 }
 .result-row .meta{
   display:flex; align-items:center; gap:8px; flex-wrap:wrap; font-size: var(--fz-sm); color: var(--text-muted);
+  transition: var(--transition);
 }
 .result-row .meta .k{ opacity:.7; }
-.result-row .meta .v{ color:var(--text); }
+.result-row .meta .v{ color:var(--text); transition: var(--transition); }
 
 .result-row .expected{
   color:var(--text-muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+  transition: var(--transition);
 }
 
 .result-row .actions{

--- a/src/modules/results/components/ResultRow.jsx
+++ b/src/modules/results/components/ResultRow.jsx
@@ -23,7 +23,7 @@ export default function ResultRow({
 }) {
   const statusClass = mapStatus(result.status);
   return (
-    <div className={`result-row ${expanded ? "expanded" : ""}`}>
+    <div className={`result-row ${expanded ? "expanded" : ""} ${result.status === "done" ? "done" : ""}`}>
       <button className="caret" aria-label="Розгорнути" onClick={() => onToggleExpand && onToggleExpand(result.id)}>
         {expanded ? "▾" : "▸"}
       </button>


### PR DESCRIPTION
## Summary
- dim completed result cards and strike through titles
- transition completion states smoothly

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689e1b4df77c8332a2af004e6d791436