### PR TITLE
Style results list items as cards

### DIFF
--- a/src/modules/results/components/ResultItem.css
+++ b/src/modules/results/components/ResultItem.css
@@ -1,0 +1,83 @@
+@import "../../../styles/variables.css";
+
+.result-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+.result-item + .result-item {
+  margin-top: var(--space-2);
+}
+
+.result-item.expanded {
+  box-shadow: var(--shadow);
+}
+
+.ri-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.ri-title {
+  flex: 1 1 auto;
+  color: var(--navy);
+  font-weight: 600;
+  text-decoration: none;
+  word-break: break-word;
+}
+
+.ri-actions {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.ri-action {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--transition), background var(--transition);
+}
+
+.ri-action:hover {
+  color: var(--primary);
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.ri-bottom {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  font-size: var(--fz-sm);
+  color: var(--text-muted);
+}
+
+.ri-deadline {
+  margin-right: var(--space-2);
+}
+
+/* статусні бейджі */
+.badge.status-new { border-color: var(--text-muted); color: var(--text-muted); }
+.badge.status-progress { border-color: var(--blue); color: var(--blue); }
+.badge.status-done { border-color: #10B981; color: #065F46; }
+.badge.status-postponed { border-color: var(--rush); color: var(--rush-dark); }
+
+@media (max-width: 600px) {
+  .ri-top {
+    flex-wrap: wrap;
+  }
+  .ri-actions {
+    margin-left: auto;
+  }
+}

--- a/src/modules/results/components/ResultItem.jsx
+++ b/src/modules/results/components/ResultItem.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { FiEdit2, FiTrash2 } from "react-icons/fi";
+import "./ResultItem.css";
+
+export default function ResultItem({
+  result,
+  expanded,
+  onToggleExpand,
+  onEdit,
+  onDelete,
+}) {
+  const statusClass = mapStatus(result.status);
+
+  const handleCardClick = () => {
+    onToggleExpand && onToggleExpand(result.id);
+  };
+
+  return (
+    <div
+      className={`result-item ${expanded ? "expanded" : ""}`}
+      onClick={handleCardClick}
+    >
+      <div className="ri-top">
+        <a
+          className="ri-title"
+          href={`/results/${result.id}`}
+          title={result.title}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {result.title}
+        </a>
+        <div className="ri-actions">
+          {onEdit && (
+            <button
+              className="ri-action"
+              aria-label="Редагувати"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(result.id);
+              }}
+            >
+              <FiEdit2 />
+            </button>
+          )}
+          {onDelete && (
+            <button
+              className="ri-action"
+              aria-label="Видалити"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(result.id);
+              }}
+            >
+              <FiTrash2 />
+            </button>
+          )}
+        </div>
+      </div>
+      <div className="ri-bottom">
+        {result.deadline && (
+          <span className="ri-deadline">До {result.deadline}</span>
+        )}
+        <span className={`badge ${statusClass}`}>
+          {humanStatus(result.status)}
+        </span>
+        {result.urgent && <span className="badge critical">Терміново</span>}
+        <span className="badge neutral">
+          Щоденних: {result.dailyTasksCount ?? 0}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function mapStatus(s) {
+  return s === "new"
+    ? "status-new"
+    : s === "in_progress"
+    ? "status-progress"
+    : s === "done"
+    ? "status-done"
+    : s === "postponed"
+    ? "status-postponed"
+    : "neutral";
+}
+
+function humanStatus(s) {
+  return s === "new"
+    ? "Новий"
+    : s === "in_progress"
+    ? "В процесі"
+    : s === "done"
+    ? "Виконано"
+    : s === "postponed"
+    ? "Відкладено"
+    : "—";
+}
+

--- a/src/modules/results/pages/ResultsPage.jsx
+++ b/src/modules/results/pages/ResultsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Layout from '../../../components/layout/Layout.jsx';
 import { getResults } from '../api/results';
-import ResultRow from '../components/ResultRow.jsx';
+import ResultItem from '../components/ResultItem.jsx';
 import ResultDetails from '../components/ResultDetails.jsx';
 import ResultsEmpty from '../components/ResultsEmpty.jsx';
 import ResultForm from '../components/ResultForm.jsx';
@@ -64,7 +64,7 @@ export default function ResultsPage() {
           <div className="results-list">
             {results.map((r) => (
               <React.Fragment key={r.id}>
-                <ResultRow
+                <ResultItem
                   result={r}
                   expanded={expanded === r.id}
                   onToggleExpand={toggleExpand}


### PR DESCRIPTION
## Summary
- add `ResultItem` component for displaying results in card layout with top actions and bottom meta
- apply card styling with soft shadow, radius, and responsive typography
- switch results page to use the new `ResultItem`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e1b369ac4833296057b62cbcba0f1