### PR TITLE
feat(results): add done toggle control

### DIFF
--- a/src/modules/results/components/ResultRow.css
+++ b/src/modules/results/components/ResultRow.css
@@ -40,6 +40,38 @@
   white-space:nowrap;
 }
 
+.result-row .done-toggle{
+  border:1px solid var(--border);
+  background:#fff;
+  border-radius:8px;
+  width:28px;
+  height:28px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+}
+.result-row .done-toggle.checked{
+  background:#10B981;
+  border-color:#10B981;
+  color:#fff;
+}
+.result-row .done-toggle:disabled{
+  opacity:.6;
+  cursor:default;
+}
+.result-row .done-toggle .spinner{
+  width:16px;
+  height:16px;
+  border:2px solid var(--border);
+  border-top-color: var(--blue);
+  border-radius:50%;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin{
+  to{ transform: rotate(360deg); }
+}
+
 @media (max-width: 1100px){
   .result-row{
     grid-template-columns: 28px 1fr auto;


### PR DESCRIPTION
## Summary
- replace wide "mark as done" button with compact toggle displaying a checkmark
- show optimistic completion state and spinner while saving

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e1b40c2608332b74809f54dd8b062