### PR TITLE
Replace result completion button with compact checkbox

### DIFF
--- a/src/modules/results/components/ResultItem.css
+++ b/src/modules/results/components/ResultItem.css
@@ -40,6 +40,38 @@
   gap: var(--space-1);
 }
 
+.ri-done-wrapper {
+  position: relative;
+}
+
+.ri-done-wrapper .check-toggle {
+  padding: var(--space-1);
+}
+
+.ri-done-wrapper.loading .check-toggle {
+  visibility: hidden;
+}
+
+.ri-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin-top: -8px;
+  margin-left: -8px;
+  border: 2px solid var(--primary);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ri-spin 0.8s linear infinite;
+}
+
+@keyframes ri-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .ri-action {
   background: transparent;
   border: none;


### PR DESCRIPTION
## Summary
- replace wide "mark as done" button with small CheckToggle control
- show optimistic status updates with loading spinner
- add accessibility labels for completion toggle

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689e1ddf18348332bc828583a0df39a6