### PR TITLE
feat: add templates management page

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -31,7 +31,6 @@ export default function Sidebar({
     const location = useLocation();
     const tasksActive =
         location.pathname.startsWith("/results") ||
-        location.pathname.startsWith("/templates") ||
         location.pathname.startsWith("/tasks");
     const { activeCompany } = useCompany();
 
@@ -101,20 +100,6 @@ export default function Sidebar({
                                     </li>
                                     <li>
                                         <NavLink
-                                            to="/templates"
-                                            className={({ isActive }) =>
-                                                `${isActive ? "active" : ""} nav-subitem`
-                                            }
-                                            onClick={handleNavClick}
-                                        >
-                                            <FiGrid className="submenu-icon" />
-                                            <span className="menu-text">
-                                                Шаблони
-                                            </span>
-                                        </NavLink>
-                                    </li>
-                                    <li>
-                                        <NavLink
                                             to="/tasks"
                                             className={({ isActive }) =>
                                                 `${isActive ? "active" : ""} nav-subitem`
@@ -129,6 +114,22 @@ export default function Sidebar({
                                     </li>
                                 </ul>
                             )}
+                        </li>
+                        <li>
+                            <NavLink
+                                to="/templates"
+                                className={({ isActive }) =>
+                                    isActive ? "active" : ""
+                                }
+                                onClick={handleNavClick}
+                            >
+                                <FiGrid className="menu-icon" />
+                                {isOpen && (
+                                    <span className="menu-text">
+                                        Шаблони
+                                    </span>
+                                )}
+                            </NavLink>
                         </li>
                         <li className="sidebar-divider" aria-hidden="true"></li>
                         <li>

--- a/src/modules/templates/api/templatesApi.js
+++ b/src/modules/templates/api/templatesApi.js
@@ -1,0 +1,24 @@
+import api from "../../../services/api";
+
+const BASE = "/templates";
+
+export const listTemplates = async () => {
+  const r = await api.get(BASE);
+  return r.data || [];
+};
+
+export const createTemplate = async (payload) => {
+  const r = await api.post(BASE, payload);
+  return r.data;
+};
+
+export const updateTemplate = async (id, payload) => {
+  const r = await api.put(`${BASE}/${id}`, payload);
+  return r.data;
+};
+
+export const deleteTemplate = async (id) => {
+  const r = await api.delete(`${BASE}/${id}`);
+  return r.data;
+};
+

--- a/src/modules/templates/pages/TemplatesPage.css
+++ b/src/modules/templates/pages/TemplatesPage.css
@@ -1,4 +1,166 @@
 @import "../../../styles/variables.css";
 
-.templates-page{ display:flex; flex-direction:column; gap:16px; }
-.tpl-list{ display:grid; }
+.templates-page {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.tp-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.tp-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.tp-error {
+  color: var(--critical);
+  font-size: var(--fz-sm);
+}
+
+.tp-table {
+  overflow: hidden;
+}
+
+.tp-row {
+  display: grid;
+  grid-template-columns: 2fr 2fr 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.tp-row--head {
+  background: var(--bg-soft);
+  font-weight: 600;
+}
+
+.tp-empty {
+  padding: 16px;
+  color: var(--text-muted);
+}
+
+.c-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.row-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent-weak);
+  color: var(--accent-text);
+  font-size: var(--fz-xs);
+}
+
+.badge.muted {
+  background: var(--bg-soft);
+  color: var(--text-muted);
+}
+
+.flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* Modal */
+.tp-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.3);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  z-index: 50;
+}
+
+.tp-modal__dialog {
+  max-width: 960px;
+  width: 100%;
+  padding: 16px;
+}
+
+.tp-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.tp-modal__body {
+  display: grid;
+  gap: 12px;
+}
+
+.tp-modal__foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* Form elements */
+.field {
+  display: grid;
+  gap: 4px;
+}
+
+.field.row {
+  grid-template-columns: 120px auto;
+  align-items: center;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+@media (max-width: 860px) {
+  .tp-row {
+    grid-template-columns: 1.5fr 1.5fr 1fr auto;
+  }
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.row2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+@media (max-width: 640px) {
+  .tp-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .tp-actions {
+    justify-content: space-between;
+  }
+  .tp-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+  .c-actions {
+    justify-content: flex-start;
+  }
+  .row2 {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/src/modules/templates/pages/TemplatesPage.jsx
+++ b/src/modules/templates/pages/TemplatesPage.jsx
@@ -1,54 +1,390 @@
-import React, { useState } from "react";
-import Layout from "../../../components/layout/Layout";
-import TemplatesFilters from "../components/TemplatesFilters";
-import TemplateRow from "../components/TemplateRow";
-import TemplateDetails from "../components/TemplateDetails";
-import TemplatesEmpty from "../components/TemplatesEmpty";
+import React, { useEffect, useMemo, useState } from "react";
 import "./TemplatesPage.css";
+import {
+  listTemplates,
+  createTemplate,
+  updateTemplate,
+  deleteTemplate,
+} from "../../templates/api/templatesApi";
 
-export default function TemplatesPage() {
-  const [filters, setFilters] = useState({ q: "", resultId: "any", priority: "any", defaultAssigneeId: "any", view: "list" });
-  const [expandedId, setExpandedId] = useState(null);
-  const data = [];
-
-  const onReset = () => setFilters({ q: "", resultId: "any", priority: "any", defaultAssigneeId: "any", view: "list" });
-  const toggleExpand = (id) => setExpandedId(expandedId === id ? null : id);
-
+function FlagsBadge({ flags = {} }) {
+  const enabled = Object.keys(flags).filter((k) => flags[k]);
+  if (!enabled.length) return <span className="badge muted">Порожній</span>;
   return (
-    <Layout>
-      <div className="templates-page">
-        <h1>Шаблони</h1>
-        <TemplatesFilters value={filters} onChange={setFilters} onReset={onReset} />
-        {data.length === 0 ? (
-          <TemplatesEmpty onCreate={() => {}} />
-        ) : (
-          <div className="tpl-list">
-            {data.map((t) => (
-              <React.Fragment key={t.id}>
-                <TemplateRow
-                  template={t}
-                  expanded={expandedId === t.id}
-                  onExpand={toggleExpand}
-                  onCreateTask={() => {}}
-                  onEdit={() => {}}
-                  onArchive={() => {}}
-                  onDelete={() => {}}
-                />
-                {expandedId === t.id && (
-                  <TemplateDetails
-                    template={t}
-                    onInlineUpdate={() => {}}
-                    onCreateTask={() => {}}
-                    onLinkResult={() => {}}
-                    onUnlinkResult={() => {}}
-                    onDuplicate={() => {}}
-                  />
-                )}
-              </React.Fragment>
-            ))}
-          </div>
-        )}
-      </div>
-    </Layout>
+    <div className="flags">
+      {enabled.map((k) => (
+        <span key={k} className="badge">
+          {k}
+        </span>
+      ))}
+    </div>
   );
 }
+
+function RowActions({ onEdit, onDelete, busy }) {
+  return (
+    <div className="row-actions">
+      <button className="btn xs ghost" onClick={onEdit} disabled={busy} title="Редагувати">
+        ✏️
+      </button>
+      <button
+        className="btn xs danger"
+        onClick={onDelete}
+        disabled={busy}
+        title="Видалити"
+      >
+        🗑️
+      </button>
+    </div>
+  );
+}
+
+export default function TemplatesPage() {
+  const [items, setItems] = useState([]);
+  const [q, setQ] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [busyId, setBusyId] = useState(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [form, setForm] = useState({
+    id: null,
+    name: "",
+    flags: {
+      title: true,
+      final_result: true,
+      description: true,
+      urgent: true,
+      responsible_id: true,
+      date: true,
+      due_date: true,
+    },
+    payload: {
+      title: "",
+      final_result: "",
+      description: "",
+      urgent: false,
+      responsible_id: null,
+      date: "",
+      due_date: "",
+    },
+  });
+  const [error, setError] = useState("");
+
+  const load = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const data = await listTemplates();
+      setItems(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setError(e?.response?.data?.message || "Не вдалося завантажити шаблони");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!q.trim()) return items;
+    const s = q.toLowerCase();
+    return items.filter((x) => (x.name || "").toLowerCase().includes(s));
+  }, [items, q]);
+
+  const openCreate = () => {
+    setForm({
+      id: null,
+      name: "",
+      flags: {
+        title: true,
+        final_result: true,
+        description: true,
+        urgent: true,
+        responsible_id: true,
+        date: true,
+        due_date: true,
+      },
+      payload: {
+        title: "",
+        final_result: "",
+        description: "",
+        urgent: false,
+        responsible_id: null,
+        date: "",
+        due_date: "",
+      },
+    });
+    setModalOpen(true);
+  };
+
+  const openEdit = (t) => {
+    setForm({
+      id: t.id,
+      name: t.name || "",
+      flags: {
+        title: !!t.flags?.title,
+        final_result: !!t.flags?.final_result,
+        description: !!t.flags?.description,
+        urgent: !!t.flags?.urgent,
+        responsible_id: !!t.flags?.responsible_id,
+        date: !!t.flags?.date,
+        due_date: !!t.flags?.due_date,
+      },
+      payload: {
+        title: t.payload?.title ?? "",
+        final_result: t.payload?.final_result ?? "",
+        description: t.payload?.description ?? "",
+        urgent: !!t.payload?.urgent,
+        responsible_id:
+          t.payload?.responsible_id === null ? null : Number(t.payload?.responsible_id || 0),
+        date: t.payload?.date ?? "",
+        due_date: t.payload?.due_date ?? "",
+      },
+    });
+    setModalOpen(true);
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    try {
+      const payload = {
+        name: form.name.trim(),
+        flags: form.flags,
+        payload: {
+          ...form.payload,
+          responsible_id:
+            form.payload.responsible_id === "" || form.payload.responsible_id === null
+              ? null
+              : Number(form.payload.responsible_id),
+        },
+      };
+      if (!payload.name) {
+        setError("Назва шаблону обов’язкова");
+        return;
+      }
+      if (form.id) {
+        setBusyId(form.id);
+        await updateTemplate(form.id, payload);
+      } else {
+        setBusyId(-1);
+        await createTemplate(payload);
+      }
+      setModalOpen(false);
+      setBusyId(null);
+      await load();
+    } catch (e2) {
+      setBusyId(null);
+      setError(e2?.response?.data?.message || "Помилка збереження");
+    }
+  };
+
+  const onDelete = async (id) => {
+    if (!window.confirm("Видалити шаблон? Дію неможливо скасувати.")) return;
+    setBusyId(id);
+    try {
+      await deleteTemplate(id);
+      await load();
+    } catch (e) {
+      setError(e?.response?.data?.message || "Не вдалося видалити шаблон");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const setFlag = (key, val) =>
+    setForm((s) => ({ ...s, flags: { ...s.flags, [key]: val } }));
+
+  const setPayload = (key, val) =>
+    setForm((s) => ({ ...s, payload: { ...s.payload, [key]: val } }));
+
+  return (
+    <div className="templates-page">
+      <div className="tp-head">
+        <h1>Шаблони</h1>
+        <div className="tp-actions">
+          <input
+            className="input"
+            placeholder="Пошук за назвою…"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+          />
+          <button className="btn primary" onClick={openCreate}>
+            + Новий шаблон
+          </button>
+        </div>
+      </div>
+
+      {error && <div className="tp-error">{error}</div>}
+
+      <div className="tp-table card">
+        <div className="tp-row tp-row--head">
+          <div className="c-name">Назва</div>
+          <div className="c-flags">Що зберігає</div>
+          <div className="c-meta">Оновлено</div>
+          <div className="c-actions">Дії</div>
+        </div>
+        {loading ? (
+          <div className="tp-empty">Завантаження…</div>
+        ) : filtered.length ? (
+          filtered.map((t) => (
+            <div key={t.id} className="tp-row">
+              <div className="c-name">{t.name}</div>
+              <div className="c-flags"><FlagsBadge flags={t.flags} /></div>
+              <div className="c-meta">
+                {t.updated_at
+                  ? new Date(t.updated_at * 1000).toLocaleString()
+                  : "—"}
+              </div>
+              <div className="c-actions">
+                <RowActions
+                  busy={busyId === t.id}
+                  onEdit={() => openEdit(t)}
+                  onDelete={() => onDelete(t.id)}
+                />
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="tp-empty">Поки що немає шаблонів</div>
+        )}
+      </div>
+
+      {modalOpen && (
+        <div className="tp-modal">
+          <div className="tp-modal__dialog card">
+            <div className="tp-modal__head">
+              <h2>{form.id ? "Редагувати шаблон" : "Новий шаблон"}</h2>
+              <button className="btn xs ghost" onClick={() => setModalOpen(false)}>✖</button>
+            </div>
+
+            <form onSubmit={onSubmit} className="tp-modal__body">
+              <label className="field">
+                <span>Назва шаблону*</span>
+                <input
+                  className="input"
+                  value={form.name}
+                  onChange={(e) => setForm((s) => ({ ...s, name: e.target.value }))}
+                  placeholder="Наприклад: Щоденний результат"
+                  required
+                />
+              </label>
+
+              <div className="grid">
+                <div className="col">
+                  <div className="group">
+                    <div className="group-title">Поля для збереження</div>
+                    {Object.entries(form.flags).map(([k, v]) => (
+                      <label key={k} className="chk">
+                        <input
+                          type="checkbox"
+                          checked={!!v}
+                          onChange={(e) => setFlag(k, e.target.checked)}
+                        />
+                        <span>{k}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="col">
+                  <div className="group">
+                    <div className="group-title">Значення полів</div>
+
+                    <label className="field">
+                      <span>title</span>
+                      <input
+                        className="input"
+                        value={form.payload.title}
+                        onChange={(e) => setPayload("title", e.target.value)}
+                      />
+                    </label>
+
+                    <label className="field">
+                      <span>final_result</span>
+                      <input
+                        className="input"
+                        value={form.payload.final_result}
+                        onChange={(e) => setPayload("final_result", e.target.value)}
+                      />
+                    </label>
+
+                    <label className="field">
+                      <span>description</span>
+                      <textarea
+                        className="input"
+                        value={form.payload.description}
+                        onChange={(e) => setPayload("description", e.target.value)}
+                      />
+                    </label>
+
+                    <label className="field row">
+                      <span>urgent</span>
+                      <input
+                        type="checkbox"
+                        checked={!!form.payload.urgent}
+                        onChange={(e) => setPayload("urgent", e.target.checked)}
+                      />
+                    </label>
+
+                    <label className="field">
+                      <span>responsible_id</span>
+                      <input
+                        className="input"
+                        type="number"
+                        min="0"
+                        step="1"
+                        value={form.payload.responsible_id ?? ""}
+                        onChange={(e) =>
+                          setPayload(
+                            "responsible_id",
+                            e.target.value === "" ? null : Number(e.target.value)
+                          )
+                        }
+                      />
+                    </label>
+
+                    <div className="row2">
+                      <label className="field">
+                        <span>date (YYYY-MM-DD)</span>
+                        <input
+                          className="input"
+                          type="date"
+                          value={form.payload.date}
+                          onChange={(e) => setPayload("date", e.target.value)}
+                        />
+                      </label>
+
+                      <label className="field">
+                        <span>due_date (HH:mm)</span>
+                        <input
+                          className="input"
+                          placeholder="09:30"
+                          value={form.payload.due_date}
+                          onChange={(e) => setPayload("due_date", e.target.value)}
+                        />
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {error && <div className="tp-error">{error}</div>}
+
+              <div className="tp-modal__foot">
+                <button className="btn ghost" type="button" onClick={() => setModalOpen(false)}>
+                  Скасувати
+                </button>
+                <button className="btn primary" type="submit" disabled={busyId !== null}>
+                  {form.id ? "Зберегти" : "Створити"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add API client for template CRUD operations
- implement templates management page with search, flags, and modal form
- style templates page and modal
- expose templates page in sidebar navigation

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689e244a7e688332874657174c2cdd4a