### PR TITLE
Add instructions page with editors and viewers list

### DIFF
--- a/src/modules/instructions/api/instructions.js
+++ b/src/modules/instructions/api/instructions.js
@@ -1,0 +1,3 @@
+import api from "../../../services/api";
+
+export const getInstructions = async () => (await api.get("/instructions")).data;

--- a/src/modules/instructions/components/InstructionItem.css
+++ b/src/modules/instructions/components/InstructionItem.css
@@ -1,0 +1,21 @@
+.instruction-item {
+    padding: 16px;
+}
+
+.instruction-item__title {
+    margin: 0 0 8px;
+    font-size: 18px;
+}
+
+.instruction-item__body {
+    margin-bottom: 12px;
+}
+
+.instruction-item__access {
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.instruction-item__access > div + div {
+    margin-top: 8px;
+}

--- a/src/modules/instructions/components/InstructionItem.jsx
+++ b/src/modules/instructions/components/InstructionItem.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import "./InstructionItem.css";
+
+export default function InstructionItem({ instruction }) {
+    const editors = (instruction.editors || []).map((u) => u.name || u).join(", ") || "—";
+    const viewers = (instruction.viewers || []).map((u) => u.name || u).join(", ") || "—";
+
+    return (
+        <div className="instruction-item card">
+            <h2 className="instruction-item__title">{instruction.title}</h2>
+            {instruction.body && (
+                <div className="instruction-item__body">{instruction.body}</div>
+            )}
+            <div className="instruction-item__access">
+                <div className="instruction-item__editors">
+                    <strong>Можуть редагувати:</strong> {editors}
+                </div>
+                <div className="instruction-item__viewers">
+                    <strong>Можуть переглядати:</strong> {viewers}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/modules/instructions/pages/InstructionsPage.css
+++ b/src/modules/instructions/pages/InstructionsPage.css
@@ -1,0 +1,15 @@
+.instructions-page {
+    padding: 20px;
+}
+
+.instructions-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.instructions-loader,
+.instructions-empty {
+    margin-top: 20px;
+}

--- a/src/modules/instructions/pages/InstructionsPage.jsx
+++ b/src/modules/instructions/pages/InstructionsPage.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+import Layout from "../../../components/layout/Layout.jsx";
+import { getInstructions } from "../api/instructions.js";
+import InstructionItem from "../components/InstructionItem.jsx";
+import "./InstructionsPage.css";
+
+export default function InstructionsPage() {
+    const [items, setItems] = useState([]);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const load = async () => {
+            setLoading(true);
+            try {
+                const data = await getInstructions();
+                setItems(data.items || data || []);
+            } catch (err) {
+                console.error("Не вдалося завантажити інструкції", err);
+            } finally {
+                setLoading(false);
+            }
+        };
+        load();
+    }, []);
+
+    return (
+        <Layout>
+            <div className="instructions-page">
+                <h1>Інструкції</h1>
+                {loading && <div className="instructions-loader">Завантаження…</div>}
+                {!loading && items.length === 0 && (
+                    <div className="instructions-empty">Немає інструкцій</div>
+                )}
+                {!loading && items.length > 0 && (
+                    <div className="instructions-list">
+                        {items.map((inst) => (
+                            <InstructionItem key={inst.id} instruction={inst} />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </Layout>
+    );
+}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -12,6 +12,7 @@ import BpEditorPage from "../modules/bp/pages/BpEditorPage";
 import OrgPage from "../modules/org/pages/OrgPage";
 import Layout from "../components/layout/Layout";
 import TelegramGroupPage from "../modules/telegram/pages/TelegramGroupPage";
+import InstructionsPage from "../modules/instructions/pages/InstructionsPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
 import ForgotPasswordPage from "../modules/auth/pages/ForgotPasswordPage";
 import ResetPasswordPage from "../modules/auth/pages/ResetPasswordPage";
@@ -117,6 +118,14 @@ export default function AppRouter() {
                 <Route element={<RequireAuth><Layout><Outlet /></Layout></RequireAuth>}>
                     <Route path="/org" element={<OrgPage />} />
                 </Route>
+                <Route
+                    path="/instructions"
+                    element={
+                        <RequireAuth>
+                            <InstructionsPage />
+                        </RequireAuth>
+                    }
+                />
                 <Route
                     path="/telegram-group"
                     element={


### PR DESCRIPTION
## Summary
- add instructions module with API and components
- display instructions with edit and view permissions
- register instructions route in router

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e29bfad648332b53e1d704ea63456