### PR TITLE
feat: attach auth token to api calls

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -17,8 +17,7 @@ import {
     FiGitBranch,
 } from "react-icons/fi";
 import CheckToggle from "../../ui/CheckToggle";
-import axios from "axios";
-import { API_BASE_URL } from "../../../config";
+import api from "../../../services/api";
 import { useCompany } from "../../../context/CompanyContext";
 
 export default function Sidebar({
@@ -279,8 +278,8 @@ export function RightSidebar() {
             )
         );
         try {
-            await axios.patch(
-                `${API_BASE_URL}/task/update-field?id=${id}`,
+            await api.patch(
+                `/task/update-field?id=${id}`,
                 { field: "status", value: newStatus }
             );
         } catch (e) {

--- a/src/modules/orgStructure/pages/OrgStructurePage.jsx
+++ b/src/modules/orgStructure/pages/OrgStructurePage.jsx
@@ -1,8 +1,7 @@
 // frontend/src/modules/org/pages/OrgStructurePage.jsx
 import React, { useEffect, useState } from "react";
 import Layout from "../../../components/layout/Layout";
-import axios from "axios";
-import { API_BASE_URL } from "../../../config";
+import api from "../../../services/api";
 
 export default function OrgStructurePage() {
     const [tree, setTree] = useState([]);
@@ -11,8 +10,8 @@ export default function OrgStructurePage() {
         async function load() {
             try {
                 const [posRes, userRes] = await Promise.all([
-                    axios.get(`${API_BASE_URL}/position`),
-                    axios.get(`${API_BASE_URL}/user`),
+                    api.get(`/position`),
+                    api.get(`/user`),
                 ]);
                 const positions = posRes.data;
                 const users = userRes.data;

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import Layout from "../../../components/layout/Layout";
 import "./DailyTasksPage.css";
 import "../../templates/components/TemplatesFilters.css";
-import axios from "axios";
-import { API_BASE_URL } from "../../../config";
+import api from "../../../services/api";
 import { formatMinutesToHours } from "../../../utils/timeFormatter";
 import { FiCalendar } from "react-icons/fi";
 import { getResults } from "../../results/api/results";
@@ -60,8 +59,8 @@ export default function DailyTasksPage() {
             if (value && value !== "any") params.append(key, value);
         });
 
-        axios
-            .get(`${API_BASE_URL}/task/filter?${params.toString()}`)
+        api
+            .get(`/task/filter?${params.toString()}`)
             .then((res) => {
                 const backendTasks = res.data?.tasks || [];
                 const mapped = backendTasks.map((t) => ({
@@ -110,8 +109,8 @@ export default function DailyTasksPage() {
         const task = tasks.find((t) => t.id === id);
         if (!task) return;
         const newStatus = task.status === "done" ? "new" : "done";
-        axios
-            .patch(`${API_BASE_URL}/task/update-field?id=${id}`, {
+        api
+            .patch(`/task/update-field?id=${id}`, {
                 field: "status",
                 value: newStatus,
             })
@@ -149,8 +148,8 @@ export default function DailyTasksPage() {
     };
 
     const updateTaskField = (id, field, value) => {
-        axios
-            .patch(`${API_BASE_URL}/task/update-field?id=${id}`, { field, value })
+        api
+            .patch(`/task/update-field?id=${id}`, { field, value })
             .then(() => {
                 setTasks((prev) =>
                     sortTasks(
@@ -179,8 +178,8 @@ export default function DailyTasksPage() {
     const openDatePicker = () => dateInputRef.current?.showPicker();
 
     useEffect(() => {
-        axios
-            .get(`${API_BASE_URL}/tasks/templates`)
+        api
+            .get(`/tasks/templates`)
             .then((r) => setTemplates(r.data?.templates || []))
             .catch(() => { });
         getResults({ status: "active" })
@@ -224,8 +223,8 @@ export default function DailyTasksPage() {
             comments: newTaskComments.trim(),
         };
         if (newTaskResultId) payload.resultId = newTaskResultId;
-        axios
-            .post(`${API_BASE_URL}/tasks/daily`, payload)
+        api
+            .post(`/tasks/daily`, payload)
             .then((res) => {
                 const newTask = {
                     id: res.data?.id || Date.now(),


### PR DESCRIPTION
## Summary
- use shared API client for task page requests
- call authenticated API when toggling task in sidebar
- load org structure via API client

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e37fb095083328a3adb3c5481096c