### PR TITLE
feat: expand template popup with task fields and recurrence

### DIFF
--- a/src/modules/templates/pages/TemplatesPage.css
+++ b/src/modules/templates/pages/TemplatesPage.css
@@ -112,6 +112,16 @@
   gap: 8px;
 }
 
+.group {
+  display: grid;
+  gap: 8px;
+}
+
+.group-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
 /* Form elements */
 .field {
   display: grid;


### PR DESCRIPTION
## Summary
- add Ukrainian-labelled fields to template creation popup matching task form
- allow setting repetition (daily, weekly, monthly, yearly or custom interval)
- style template modal sections for cleaner layout

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e3b867d1c8332b93714a1bde1cd93