### PR TITLE
feat(tasks): show message when no tasks for today

### DIFF
--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -128,6 +128,10 @@
   margin-top: 20px;
 }
 
+.tasks-empty {
+  margin-top: 20px;
+}
+
 .add-task-form {
   display: flex;
   flex-wrap: wrap;

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -491,8 +491,11 @@ export default function DailyTasksPage() {
                 </div>
             )}
 
-            <div className="tasks-list">
-                {tasks.map((task) => (
+            {tasks.length === 0 ? (
+                <div className="tasks-empty">Задач на сьогодні не додано</div>
+            ) : (
+                <div className="tasks-list">
+                    {tasks.map((task) => (
                     <React.Fragment key={task.id}>
                         <div
                             className={`task-row ${task.status === "done" ? "is-completed" : ""
@@ -668,8 +671,9 @@ export default function DailyTasksPage() {
                             </div>
                         )}
                     </React.Fragment>
-                ))}
-            </div>
+                    ))}
+                </div>
+            )}
 
             <div className="card tasks-summary">
                 Сумарний очікуваний час: {formatMinutesToHours(totalExpected)}


### PR DESCRIPTION
## Summary
- display message when daily task list is empty
- add basic styling for empty task notice

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689e4723bdb883328f1770860721e89c