### PR TITLE
Remove template save fields block and enable modal scroll

### DIFF
--- a/src/modules/templates/pages/TemplatesPage.css
+++ b/src/modules/templates/pages/TemplatesPage.css
@@ -92,6 +92,8 @@
   max-width: 960px;
   width: 100%;
   padding: 16px;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
 }
 
 .tp-modal__head {

--- a/src/modules/templates/pages/TemplatesPage.jsx
+++ b/src/modules/templates/pages/TemplatesPage.jsx
@@ -198,9 +198,6 @@ export default function TemplatesPage() {
     }
   };
 
-  const setFlag = (key, val) =>
-    setForm((s) => ({ ...s, flags: { ...s.flags, [key]: val } }));
-
   const setPayload = (key, val) =>
     setForm((s) => ({ ...s, payload: { ...s.payload, [key]: val } }));
 
@@ -277,26 +274,8 @@ export default function TemplatesPage() {
                 />
               </label>
 
-              <div className="grid">
-                <div className="col">
-                  <div className="group">
-                    <div className="group-title">Поля для збереження</div>
-                    {Object.entries(FIELD_LABELS).map(([k, label]) => (
-                      <label key={k} className="chk">
-                        <input
-                          type="checkbox"
-                          checked={!!form.flags[k]}
-                          onChange={(e) => setFlag(k, e.target.checked)}
-                        />
-                        <span>{label}</span>
-                      </label>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="col">
-                  <div className="group">
-                    <div className="group-title">Значення полів</div>
+              <div className="group">
+                <div className="group-title">Значення полів</div>
 
                     <label className="field">
                       <span>Назва задачі</span>
@@ -339,7 +318,7 @@ export default function TemplatesPage() {
                       </select>
                     </label>
 
-                    <div className="row2">
+                <div className="row2">
                       <label className="field">
                         <span>Запланований час</span>
                         <input
@@ -429,8 +408,6 @@ export default function TemplatesPage() {
                       )}
                     </div>
                   </div>
-                </div>
-              </div>
 
               {error && <div className="tp-error">{error}</div>}
 


### PR DESCRIPTION
## Summary
- remove the "Поля для збереження" checkbox section from the template modal
- add max-height and vertical scroll to the template modal dialog so long forms fit on screen

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e4772b02c8332b706988042de0b27