### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/src/components/layout/Layout.css
+++ b/src/components/layout/Layout.css
@@ -66,3 +66,20 @@
     right: 0;
     border-radius: var(--radius-sm) 0 0 var(--radius-sm);
 }
+
+@media (max-width: 768px) {
+    .layout-column {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .layout.left-open .layout-column,
+    .layout.right-open .layout-column {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .sidebar-handle {
+        display: none;
+    }
+}

--- a/src/components/layout/Sidebar/Sidebar.css
+++ b/src/components/layout/Sidebar/Sidebar.css
@@ -265,3 +265,11 @@
     border-top: 1px solid var(--border);
     font-size: var(--fz-sm);
 }
+
+@media (max-width: 768px) {
+    .sidebar,
+    .right-sidebar {
+        width: 80%;
+        max-width: 280px;
+    }
+}

--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -157,3 +157,42 @@
   border-color: var(--red, #e00);
 }
 
+@media (max-width: 600px) {
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .page-header-actions {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .task-row {
+    grid-template-columns: 24px 1fr;
+    grid-template-rows: repeat(4, auto);
+    gap: 8px;
+  }
+
+  .task-row .title {
+    white-space: normal;
+  }
+
+  .task-row .badge.neutral,
+  .task-row .task-date,
+  .task-row .timer-cell,
+  .task-row .actions {
+    grid-column: 2;
+  }
+
+  .task-row .actions {
+    justify-content: flex-start;
+  }
+
+  .task-details {
+    margin-left: 0;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add mobile breakpoints for layout margins and sidebar widths
- reorganize DailyTasksPage layout on small screens

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e4b5d46108332b6e9aeab7d4de0a3