### PR TITLE
Embed total expected time row in tasks list

### DIFF
--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -125,7 +125,7 @@
 }
 
 .tasks-summary {
-  margin-top: 20px;
+  font-weight: 600;
 }
 
 .add-task-form {

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -669,10 +669,18 @@ export default function DailyTasksPage() {
                         )}
                     </React.Fragment>
                 ))}
-            </div>
-
-            <div className="card tasks-summary">
-                Сумарний очікуваний час: {formatMinutesToHours(totalExpected)}
+            {totalExpected > 0 && (
+                <div className="task-row tasks-summary">
+                    <span></span>
+                    <div className="title-cell">Сумарний очікуваний час</div>
+                    <span className="badge neutral">
+                        {formatMinutesToHours(totalExpected)}
+                    </span>
+                    <span className="task-date"></span>
+                    <div className="timer-cell"></div>
+                    <div className="actions"></div>
+                </div>
+            )}
             </div>
         </Layout>
     );


### PR DESCRIPTION
## Summary
- move summary of expected time inside tasks list
- hide summary when total time is zero

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e4a41b19083329325e457142677a0