### PR TITLE
feat: streamline my tasks filters and layout

### DIFF
--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 12px;
 }
 
 .page-header-left {

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -18,7 +18,6 @@ export default function DailyTasksPage() {
         priority: "any",
         timer: "any",
         result: "any",
-        assignee: "any",
     });
     const [timers, setTimers] = useState({});
     const [activeTimerId, setActiveTimerId] = useState(null);
@@ -106,7 +105,6 @@ export default function DailyTasksPage() {
             priority: "any",
             timer: "any",
             result: "any",
-            assignee: "any",
         };
         setFilters(base);
         loadTasks(formatDateForApi(selectedDate), base);
@@ -296,9 +294,6 @@ export default function DailyTasksPage() {
                             onChange={(e) => setSelectedDate(new Date(e.target.value))}
                         />
                     </h1>
-                    {filters.assignee !== "any" && filters.assignee !== "" && (
-                        <span className="muted">Виконавець: {filters.assignee}</span>
-                    )}
                 </div>
                 <div className="page-header-actions">
                     <button
@@ -395,17 +390,6 @@ export default function DailyTasksPage() {
                             </select>
                         </label>
 
-                        <label className="tf-field">
-                            <span>Виконавець</span>
-                            <select
-                                value={filters.assignee}
-                                onChange={(e) =>
-                                    handleFilterChange({ assignee: e.target.value })
-                                }
-                            >
-                                <option value="any">Будь‑хто</option>
-                            </select>
-                        </label>
                     </div>
 
                     <div className="tf-actions">

--- a/src/modules/templates/components/TemplatesFilters.css
+++ b/src/modules/templates/components/TemplatesFilters.css
@@ -1,13 +1,13 @@
 @import "../../../styles/variables.css";
 
-.tpl-filters{ padding:12px; }
+.tpl-filters{ padding:8px; }
 
-.tf-row{ display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
+.tf-row{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
 
 .tf-search{
-  display:flex; align-items:center; gap:10px;
+  display:flex; align-items:center; gap:8px;
   border:1px solid var(--border); border-radius: var(--radius-sm);
-  padding:6px 10px; background:#fff; min-width:320px; flex:1;
+  padding:4px 8px; background:#fff; min-width:320px; flex:1;
 }
 .tf-search .ico{ width:18px; height:18px; color: var(--text-muted); }
 .tf-search input{
@@ -15,14 +15,14 @@
   font-size: var(--fz-base); color: var(--text);
 }
 
-.tf-group{ display:flex; gap:10px; flex-wrap:wrap; }
+.tf-group{ display:flex; gap:8px; flex-wrap:wrap; }
 .tf-field{
-  display:flex; flex-direction:column; gap:6px;
+  display:flex; flex-direction:column; gap:4px;
   font-size: var(--fz-sm); color: var(--text-muted);
 }
 .tf-field select{
   border:1px solid var(--border); border-radius: var(--radius-sm);
-  background:#fff; padding:8px 10px; min-width:160px;
+  background:#fff; padding:6px 8px; min-width:160px;
 }
 
 .tf-actions{ margin-left:auto; display:flex; gap:8px; }


### PR DESCRIPTION
## Summary
- remove redundant assignee filter from My Tasks page
- tighten spacing so filters block is more compact

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e4aa2d8488332ba6b13ac28d09aeb