### PR TITLE
feat: color coded task type filters

### DIFF
--- a/src/modules/tasks/components/TaskFilters.jsx
+++ b/src/modules/tasks/components/TaskFilters.jsx
@@ -42,11 +42,35 @@ export default function TaskFilters({
         <div className="task-filters-wrapper">
             {/* 🔹 Рядок із фільтрами */}
             <div className="filters-row">
-                <select className="filter-select" onChange={(e) => onTypeFilterChange(e.target.value)}>
+                <select
+                    className="filter-select"
+                    onChange={(e) => onTypeFilterChange(e.target.value)}
+                >
                     <option value="">Всі типи</option>
-                    <option value="важлива">Важлива</option>
-                    <option value="термінова">Термінова</option>
-                    <option value="звичайна">Звичайна</option>
+                    <option
+                        value="важлива термінова"
+                        style={{ background: "red", color: "#fff" }}
+                    >
+                        Важлива термінова
+                    </option>
+                    <option
+                        value="важлива нетермінова"
+                        style={{ background: "blue", color: "#fff" }}
+                    >
+                        Важлива нетермінова
+                    </option>
+                    <option
+                        value="неважлива термінова"
+                        style={{ background: "purple", color: "#fff" }}
+                    >
+                        Неважлива термінова
+                    </option>
+                    <option
+                        value="неважлива нетермінова"
+                        style={{ background: "transparent", color: "inherit" }}
+                    >
+                        Неважлива нетермінова
+                    </option>
                 </select>
 
                 <select className="filter-select" onChange={(e) => onCreatorFilterChange(e.target.value)}>

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -50,6 +50,13 @@ export default function DailyTasksPage() {
         "неважлива термінова": 3,
         "неважлива нетермінова": 4,
     };
+
+    const priorityStyles = {
+        critical: { background: "red", color: "#fff" },
+        important: { background: "blue", color: "#fff" },
+        rush: { background: "purple", color: "#fff" },
+        neutral: { background: "transparent", color: "inherit" },
+    };
     const sortTasks = (arr) =>
         [...arr].sort((a, b) => {
             if (a.status === "done" && b.status !== "done") return 1;
@@ -358,18 +365,36 @@ export default function DailyTasksPage() {
                         </label>
 
                         <label className="tf-field">
-                            <span>Пріоритет/тип</span>
+                            <span>Тип</span>
                             <select
                                 value={filters.priority}
                                 onChange={(e) =>
                                     handleFilterChange({ priority: e.target.value })
                                 }
+                                style={priorityStyles[filters.priority] || {}}
                             >
                                 <option value="any">Будь‑який</option>
-                                <option value="critical">critical</option>
-                                <option value="important">important</option>
-                                <option value="rush">rush</option>
-                                <option value="neutral">neutral</option>
+                                <option
+                                    value="critical"
+                                    style={priorityStyles.critical}
+                                >
+                                    Важлива термінова
+                                </option>
+                                <option
+                                    value="important"
+                                    style={priorityStyles.important}
+                                >
+                                    Важлива нетермінова
+                                </option>
+                                <option value="rush" style={priorityStyles.rush}>
+                                    Неважлива термінова
+                                </option>
+                                <option
+                                    value="neutral"
+                                    style={priorityStyles.neutral}
+                                >
+                                    Неважлива нетермінова
+                                </option>
                             </select>
                         </label>
 


### PR DESCRIPTION
## Summary
- color-coded type filters on task page
- add styled options to TaskFilters component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e4b073b608332ab438e27b1912a48