### PR TITLE
Sort tasks after toggling completion

### DIFF
--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -138,7 +138,11 @@ export default function DailyTasksPage() {
             })
             .catch(() => { });
         setTasks((prev) =>
-            prev.map((t) => (t.id === id ? { ...t, status: newStatus } : t))
+            sortTasks(
+                prev.map((t) =>
+                    t.id === id ? { ...t, status: newStatus } : t
+                )
+            )
         );
     };
 


### PR DESCRIPTION
## Summary
- ensure task list is re-sorted when completion state changes

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689e4fba384c8332a79a7c0de7b3a522