### PR TITLE
feat: add instruction list with icons and modal

### DIFF
--- a/src/modules/instructions/components/InstructionItem.css
+++ b/src/modules/instructions/components/InstructionItem.css
@@ -1,10 +1,18 @@
 .instruction-item {
-    padding: 16px;
+    padding: 12px 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+}
+
+.instruction-item__icon {
+    font-size: 20px;
 }
 
 .instruction-item__title {
-    margin: 0 0 8px;
-    font-size: 18px;
+    margin: 0;
+    font-size: 16px;
 }
 
 .instruction-item__body {

--- a/src/modules/instructions/components/InstructionItem.jsx
+++ b/src/modules/instructions/components/InstructionItem.jsx
@@ -1,24 +1,21 @@
 import React from "react";
 import "./InstructionItem.css";
 
-export default function InstructionItem({ instruction }) {
-    const editors = (instruction.editors || []).map((u) => u.name || u).join(", ") || "—";
-    const viewers = (instruction.viewers || []).map((u) => u.name || u).join(", ") || "—";
-
+export default function InstructionItem({ instruction, onClick }) {
     return (
-        <div className="instruction-item card">
-            <h2 className="instruction-item__title">{instruction.title}</h2>
-            {instruction.body && (
-                <div className="instruction-item__body">{instruction.body}</div>
-            )}
-            <div className="instruction-item__access">
-                <div className="instruction-item__editors">
-                    <strong>Можуть редагувати:</strong> {editors}
-                </div>
-                <div className="instruction-item__viewers">
-                    <strong>Можуть переглядати:</strong> {viewers}
-                </div>
-            </div>
+        <div
+            className="instruction-item card"
+            onClick={onClick}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    onClick?.();
+                }
+            }}
+        >
+            <span className="instruction-item__icon" aria-hidden="true">📄</span>
+            <span className="instruction-item__title">{instruction.title}</span>
         </div>
     );
 }

--- a/src/modules/instructions/pages/InstructionsPage.css
+++ b/src/modules/instructions/pages/InstructionsPage.css
@@ -13,3 +13,28 @@
 .instructions-empty {
     margin-top: 20px;
 }
+
+.instruction-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.3);
+    display: grid;
+    place-items: center;
+    padding: 16px;
+    z-index: 50;
+}
+
+.instruction-modal__dialog {
+    width: 100%;
+    max-width: 600px;
+    padding: 16px;
+    max-height: calc(100vh - 32px);
+    overflow-y: auto;
+}
+
+.instruction-modal__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+}

--- a/src/modules/instructions/pages/InstructionsPage.jsx
+++ b/src/modules/instructions/pages/InstructionsPage.jsx
@@ -7,6 +7,7 @@ import "./InstructionsPage.css";
 export default function InstructionsPage() {
     const [items, setItems] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [selected, setSelected] = useState(null);
 
     useEffect(() => {
         const load = async () => {
@@ -34,8 +35,48 @@ export default function InstructionsPage() {
                 {!loading && items.length > 0 && (
                     <div className="instructions-list">
                         {items.map((inst) => (
-                            <InstructionItem key={inst.id} instruction={inst} />
+                            <InstructionItem
+                                key={inst.id}
+                                instruction={inst}
+                                onClick={() => setSelected(inst)}
+                            />
                         ))}
+                    </div>
+                )}
+
+                {selected && (
+                    <div className="instruction-modal" onClick={() => setSelected(null)}>
+                        <div
+                            className="instruction-modal__dialog card"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <div className="instruction-modal__head">
+                                <h2>{selected.title}</h2>
+                                <button
+                                    className="btn xs ghost"
+                                    onClick={() => setSelected(null)}
+                                >
+                                    ✖
+                                </button>
+                            </div>
+                            {selected.body && (
+                                <div className="instruction-item__body">{selected.body}</div>
+                            )}
+                            <div className="instruction-item__access">
+                                <div className="instruction-item__editors">
+                                    <strong>Можуть редагувати:</strong>{" "}
+                                    {(selected.editors || [])
+                                        .map((u) => u.name || u)
+                                        .join(", ") || "—"}
+                                </div>
+                                <div className="instruction-item__viewers">
+                                    <strong>Можуть переглядати:</strong>{" "}
+                                    {(selected.viewers || [])
+                                        .map((u) => u.name || u)
+                                        .join(", ") || "—"}
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Summary
- show instruction titles with document icons
- open full instruction in modal on click

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e50770e908332987c9054cb02d533