### PR TITLE
feat: add breadcrumbs to business process editor

### DIFF
--- a/src/components/ui/Breadcrumbs.css
+++ b/src/components/ui/Breadcrumbs.css
@@ -1,0 +1,21 @@
+.breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.breadcrumbs a {
+  color: #1f2937;
+  text-decoration: none;
+}
+
+.breadcrumbs a:hover {
+  text-decoration: underline;
+}
+
+.breadcrumbs .sep {
+  margin: 0 4px;
+  color: #9ca3af;
+}

--- a/src/components/ui/Breadcrumbs.jsx
+++ b/src/components/ui/Breadcrumbs.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import "./Breadcrumbs.css";
+
+export default function Breadcrumbs({ items = [] }) {
+  return (
+    <nav className="breadcrumbs" aria-label="breadcrumbs">
+      {items.map((item, i) => (
+        <span key={i} className="crumb">
+          {item.to ? <Link to={item.to}>{item.label}</Link> : <span>{item.label}</span>}
+          {i < items.length - 1 && <span className="sep">/</span>}
+        </span>
+      ))}
+    </nav>
+  );
+}

--- a/src/modules/businessProcesses/pages/BusinessProcessEditPage.jsx
+++ b/src/modules/businessProcesses/pages/BusinessProcessEditPage.jsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import Layout from "../../../components/layout/Layout";
+import Breadcrumbs from "../../../components/ui/Breadcrumbs";
 import api from "../../../services/api";
 import "./BusinessProcessEditPage.css";
 
@@ -374,6 +375,12 @@ export default function BusinessProcessEditPage() {
     return (
       <Layout>
         <div className="bp-edit-page">
+          <Breadcrumbs
+            items={[
+              { label: "Бізнес процеси", to: "/business-processes" },
+              { label: isNew ? "Новий бізнес‑процес" : name },
+            ]}
+          />
           <div className="loader">Завантаження…</div>
         </div>
       </Layout>
@@ -382,6 +389,12 @@ export default function BusinessProcessEditPage() {
   return (
     <Layout>
       <div className="bp-edit-page">
+        <Breadcrumbs
+          items={[
+            { label: "Бізнес процеси", to: "/business-processes" },
+            { label: isNew ? "Новий бізнес‑процес" : name },
+          ]}
+        />
         <div className="bp-header">
           <div className="bp-title">
             <span>Бізнес процес — </span>


### PR DESCRIPTION
## Summary
- add reusable breadcrumbs component
- show breadcrumbs on business process edit page

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689e511173bc8332ab15d422fb4074a5