### PR TITLE
Expand results inline instead of navigation

### DIFF
--- a/src/modules/results/components/ResultItem.jsx
+++ b/src/modules/results/components/ResultItem.jsx
@@ -46,14 +46,9 @@ export default function ResultItem({
       onClick={handleCardClick}
     >
       <div className="ri-top">
-        <a
-          className="ri-title"
-          href={`/results/${result.id}`}
-          title={result.title}
-          onClick={(e) => e.stopPropagation()}
-        >
+        <span className="ri-title" title={result.title}>
           {result.title}
-        </a>
+        </span>
         <div className="ri-actions">
           <div className={`ri-done-wrapper ${loading ? "loading" : ""}`}>
             <CheckToggle


### PR DESCRIPTION
## Summary
- Prevent result item title from navigating away and allow inline expansion

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e59d12fd8833296d4e53b07d7c1fc