### PR TITLE
Enable adding subresults from results page

### DIFF
--- a/src/modules/results/components/ResultForm.jsx
+++ b/src/modules/results/components/ResultForm.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import api from '../../../services/api';
 import './ResultForm.css';
 
-export default function ResultForm({ onSaved, onCancel }) {
+export default function ResultForm({ onSaved, onCancel, parentId }) {
   const [form, setForm] = useState({
     title: '',
     final_result: '',
@@ -81,7 +81,11 @@ export default function ResultForm({ onSaved, onCancel }) {
         responsible_id: form.responsible_id ? Number(form.responsible_id) : null
       };
 
-      await api.post('/results', payload);
+      if (parentId) {
+        await api.post(`/results/${parentId}/children`, payload);
+      } else {
+        await api.post('/results', payload);
+      }
 
       onSaved && onSaved();
 

--- a/src/modules/results/pages/ResultsPage.jsx
+++ b/src/modules/results/pages/ResultsPage.jsx
@@ -12,6 +12,7 @@ export default function ResultsPage() {
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState(null);
   const [showAddForm, setShowAddForm] = useState(false);
+  const [parentId, setParentId] = useState(null);
 
   const fetchResults = async () => {
     setLoading(true);
@@ -30,11 +31,17 @@ export default function ResultsPage() {
 
   const handleSaved = () => {
     setShowAddForm(false);
+    setParentId(null);
     fetchResults();
   };
 
   const toggleExpand = (id) => {
     setExpanded((prev) => (prev === id ? null : id));
+  };
+
+  const handleAddSubresult = (id) => {
+    setParentId(id);
+    setShowAddForm(true);
   };
 
   return (
@@ -43,7 +50,13 @@ export default function ResultsPage() {
         <div className="results-page__header">
           <h1>Результати</h1>
           {!showAddForm && (
-            <button className="btn primary" onClick={() => setShowAddForm(true)}>
+            <button
+              className="btn primary"
+              onClick={() => {
+                setParentId(null);
+                setShowAddForm(true);
+              }}
+            >
               Додати результат
             </button>
           )}
@@ -51,14 +64,25 @@ export default function ResultsPage() {
 
         {showAddForm && (
           <ResultForm
+            parentId={parentId}
             onSaved={handleSaved}
-            onCancel={() => setShowAddForm(false)}
+            onCancel={() => {
+              setShowAddForm(false);
+              setParentId(null);
+            }}
           />
         )}
 
         {loading && <div className="results-loader">Завантаження…</div>}
 
-        {!loading && results.length === 0 && <ResultsEmpty onCreate={() => setShowAddForm(true)} />}
+        {!loading && results.length === 0 && (
+          <ResultsEmpty
+            onCreate={() => {
+              setParentId(null);
+              setShowAddForm(true);
+            }}
+          />
+        )}
 
         {!loading && results.length > 0 && (
           <div className="results-list">
@@ -69,7 +93,12 @@ export default function ResultsPage() {
                   expanded={expanded === r.id}
                   onToggleExpand={toggleExpand}
                 />
-                {expanded === r.id && <ResultDetails result={r} />}
+                {expanded === r.id && (
+                  <ResultDetails
+                    result={r}
+                    onAddSubresult={handleAddSubresult}
+                  />
+                )}
               </React.Fragment>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- allow adding a subresult from result details
- handle subresult form submission

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e5a3465d083329a837ed78d67211a