### PR TITLE
Add voice dictation for new tasks, results and templates

### DIFF
--- a/src/modules/results/components/ResultForm.jsx
+++ b/src/modules/results/components/ResultForm.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import api from '../../../services/api';
 import './ResultForm.css';
+import VoiceInput from '../../../shared/components/VoiceInput';
 
 export default function ResultForm({ onSaved, onCancel }) {
   const [form, setForm] = useState({
@@ -48,6 +49,19 @@ export default function ResultForm({ onSaved, onCancel }) {
       setDateValid(selected >= today || val === '');
     }
   };
+  const handleVoice = (data) => {
+    setForm((prev) => ({
+      ...prev,
+      title: data.title || prev.title,
+      final_result: data.final_result || prev.final_result,
+      date: data.date || prev.date,
+      due_date: data.due_date || prev.due_date,
+      urgent: data.urgent !== undefined ? data.urgent : prev.urgent,
+      description: data.description || prev.description,
+      responsible_id: data.responsible_id ? String(data.responsible_id) : prev.responsible_id,
+    }));
+  };
+
 
   const todayStr = new Date().toISOString().split('T')[0];
 
@@ -112,6 +126,7 @@ export default function ResultForm({ onSaved, onCancel }) {
   return (
     <div className="result-form card">
       <form onSubmit={handleSubmit}>
+        <VoiceInput endpoint="/results/voice" onResult={handleVoice} />
         <label className="rf-field">
           <span>Назва*</span>
           <input

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -8,6 +8,7 @@ import { FiCalendar } from "react-icons/fi";
 import { getResults } from "../../results/api/results";
 import { useAuth } from "../../../context/AuthContext";
 import TaskComments from "../components/TaskComments";
+import VoiceInput from "../../../shared/components/VoiceInput";
 
 export default function DailyTasksPage() {
     const [selectedDate, setSelectedDate] = useState(new Date());
@@ -239,6 +240,17 @@ export default function DailyTasksPage() {
         }
     };
 
+    const handleVoiceTask = (data) => {
+        if (data.title) setNewTaskTitle(data.title);
+        if (data.description) setNewTaskDescription(data.description);
+        if (data.expected_result) setNewTaskExpectedResult(data.expected_result);
+        if (data.type) setNewTaskType(data.type);
+        if (data.planned_time) setPlannedTime(data.planned_time);
+        if (data.manager) setTaskManager(data.manager);
+        if (data.comments) setNewTaskComments(data.comments);
+        if (data.resultId) setNewTaskResultId(String(data.resultId));
+    };
+
     const handleCreateTask = () => {
         if (!newTaskTitle.trim()) {
             setTitleError(true);
@@ -460,6 +472,7 @@ export default function DailyTasksPage() {
 
             {isFormOpen && (
                 <div className="add-task-form card">
+                    <VoiceInput endpoint="/tasks/voice" onResult={handleVoiceTask} />
                     <input
                         type="text"
                         className={`title-input ${titleError ? "error" : ""}`}

--- a/src/modules/templates/pages/TemplatesPage.jsx
+++ b/src/modules/templates/pages/TemplatesPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import Layout from "../../../components/layout/Layout";
 import "./TemplatesPage.css";
+import VoiceInput from "../../../shared/components/VoiceInput";
 import {
   listTemplates,
   createTemplate,
@@ -165,6 +166,26 @@ export default function TemplatesPage() {
               : { type: form.payload.repeat?.type || "none", interval: 1 },
         },
       };
+
+  const handleVoiceTemplate = (data) => {
+    setForm((s) => ({
+      ...s,
+      name: data.name || s.name,
+      flags: { ...s.flags, ...(data.flags || {}) },
+      payload: { ...s.payload, ...(data.payload || {
+        title: data.title,
+        expected_result: data.expected_result,
+        result: data.result,
+        type: data.type,
+        planned_time: data.planned_time,
+        actual_time: data.actual_time,
+        manager: data.manager,
+        comments: data.comments,
+        resultId: data.resultId,
+        repeat: data.repeat
+      })}
+    }));
+  };
       if (!payload.name) {
         setError("Назва шаблону обов’язкова");
         return;
@@ -263,6 +284,7 @@ export default function TemplatesPage() {
             </div>
 
             <form onSubmit={onSubmit} className="tp-modal__body">
+              <VoiceInput endpoint="/templates/voice" onResult={handleVoiceTemplate} />
               <label className="field">
                 <span>Назва шаблону*</span>
                 <input

--- a/src/shared/components/VoiceInput.css
+++ b/src/shared/components/VoiceInput.css
@@ -1,0 +1,14 @@
+.voice-btn {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  margin-bottom: 4px;
+}
+
+.voice-btn.recording {
+  color: red;
+}

--- a/src/shared/components/VoiceInput.jsx
+++ b/src/shared/components/VoiceInput.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useRef } from "react";
+import { FiMic, FiStopCircle } from "react-icons/fi";
+import api from "../../services/api";
+import "./VoiceInput.css";
+
+/**
+ * Кнопка для запису голосу і надсилання аудіо на бекенд.
+ * @param {string} endpoint - URL ендпоінту, куди надсилати FormData з аудіо
+ * @param {function} onResult - викликається з розпізнаним JSON після відповіді бекенду
+ */
+export default function VoiceInput({ endpoint, onResult }) {
+  const [recording, setRecording] = useState(false);
+  const mediaRef = useRef(null);
+  const chunksRef = useRef([]);
+
+  const toggleRecord = async () => {
+    if (!recording) {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        const recorder = new MediaRecorder(stream);
+        mediaRef.current = recorder;
+        recorder.ondataavailable = (e) => {
+          if (e.data.size > 0) chunksRef.current.push(e.data);
+        };
+        recorder.onstop = async () => {
+          const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+          chunksRef.current = [];
+          const form = new FormData();
+          form.append("file", blob, "voice.webm");
+          try {
+            const res = await api.post(endpoint, form, {
+              headers: { "Content-Type": "multipart/form-data" },
+            });
+            onResult && onResult(res.data || {});
+          } catch (err) {
+            console.error("Voice upload failed", err);
+          }
+        };
+        recorder.start();
+        setRecording(true);
+      } catch (err) {
+        console.error("Mic init failed", err);
+      }
+    } else {
+      mediaRef.current && mediaRef.current.stop();
+      setRecording(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={`voice-btn ${recording ? "recording" : ""}`}
+      onClick={toggleRecord}
+      title={recording ? "Зупинити" : "Надиктувати"}
+    >
+      {recording ? <FiStopCircle /> : <FiMic />}
+    </button>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable `VoiceInput` component for recording audio and sending it to backend
- integrate microphone button on daily task form to auto-fill fields from speech
- enable voice-filled creation of results and templates via the same component

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689e5d0251948332bdac2e76774a3981