### PR TITLE
feat: send task comments to backend

### DIFF
--- a/src/modules/tasks/components/TaskItem.jsx
+++ b/src/modules/tasks/components/TaskItem.jsx
@@ -257,12 +257,11 @@ export default function TaskItem({
 
                     {/* Коментарі */}
                     <TaskComments
+                        taskId={task.id}
+                        author="Я"
                         comments={task.comments}
-                        onAddComment={(text) =>
-                            onUpdateField(task.id, "comments", [
-                                ...task.comments,
-                                { author: "Я", text, replies: [] },
-                            ])
+                        onCommentsChange={(updated) =>
+                            onUpdateField(task.id, "comments", updated)
                         }
                     />
                 </div>

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -720,21 +720,20 @@ export default function DailyTasksPage() {
                                     </label>
 
                                     <TaskComments
+                                        taskId={task.id}
+                                        author={user?.name || "Я"}
                                         comments={task.comments}
-                                        onAddComment={({ text, parentId }) => {
-                                            const author = user?.name || "Я";
-                                            const updated = [...task.comments];
-                                            if (parentId === null) {
-                                                updated.push({ author, text, replies: [] });
-                                            } else if (updated[parentId]) {
-                                                const replies = updated[parentId].replies || [];
-                                                updated[parentId] = {
-                                                    ...updated[parentId],
-                                                    replies: [...replies, { author, text }],
-                                                };
-                                            }
-                                            updateTaskField(task.id, "comments", updated);
-                                        }}
+                                        onCommentsChange={(updated) =>
+                                            setTasks((prev) =>
+                                                sortTasks(
+                                                    prev.map((t) =>
+                                                        t.id === task.id
+                                                            ? { ...t, comments: updated }
+                                                            : t
+                                                    )
+                                                )
+                                            )
+                                        }
                                     />
                                 </div>
                             )}


### PR DESCRIPTION
## Summary
- send task comments to backend when adding main comment or reply
- pass task id and author to comments widget and update tasks state on change

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e5e6cc9508332a609fdca08e92de8