### PR TITLE
feat: add lane slots for node creation

### DIFF
--- a/src/modules/businessProcesses/pages/BusinessProcessEditPage.css
+++ b/src/modules/businessProcesses/pages/BusinessProcessEditPage.css
@@ -153,7 +153,46 @@
 
 .bp-node-actions { display: flex; gap: 6px; flex-wrap: wrap; }
 
-.bp-add-blocks { display: flex; gap: 8px; flex: 0 0 auto; }
+
+.bp-slot {
+  width: 100px;
+  height: 100px;
+  border: 2px dashed #d1d5db;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.bp-slot-plus {
+  opacity: 0;
+  font-size: 32px;
+  color: #6b7280;
+  transition: opacity 0.2s;
+  pointer-events: none;
+}
+
+.bp-slot:hover .bp-slot-plus {
+  opacity: 1;
+}
+
+.bp-slot-popup {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 6px);
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 20;
+}
 
 .btn { border: none; background: #ff7a00; color: #fff; border-radius: 10px; padding: 8px 12px; cursor: pointer; }
 .btn.ghost { background: #f3f4f6; color: #111827; }

--- a/src/modules/businessProcesses/pages/BusinessProcessEditPage.jsx
+++ b/src/modules/businessProcesses/pages/BusinessProcessEditPage.jsx
@@ -607,15 +607,14 @@ export default function BusinessProcessEditPage() {
                     </div>
                   ))}
 
-                  {/* Додавання в кінець */}
-                  <div className="bp-add-blocks">
-                    <button className="btn small" onClick={() => addNode(lane.id, "action", null)}>
-                      + Додати дію
-                    </button>
-                    <button className="btn small ghost" onClick={() => addNode(lane.id, "if", null)}>
-                      + Додати IF
-                    </button>
-                  </div>
+                  {Array.from({ length: 10 }).map((_, idx) => (
+                    <AddSlot
+                      key={`slot-${idx}`}
+                      laneId={lane.id}
+                      addNode={addNode}
+                      onNodeDropAfter={onNodeDropAfter}
+                    />
+                  ))}
                 </div>
               </div>
             );
@@ -630,6 +629,60 @@ export default function BusinessProcessEditPage() {
 }
 
 // ---------------- Subcomponents ----------------
+
+function AddSlot({ laneId, addNode, onNodeDropAfter }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleAdd = (type) => {
+    addNode(laneId, type, null);
+    setOpen(false);
+  };
+
+  return (
+    <div
+      className="bp-slot"
+      ref={ref}
+      onClick={() => setOpen(true)}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={(e) => onNodeDropAfter(e, laneId, null)}
+    >
+      <span className="bp-slot-plus">+</span>
+      {open && (
+        <div className="bp-slot-popup" onClick={(e) => e.stopPropagation()}>
+          <button
+            className="btn tiny"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleAdd("action");
+            }}
+          >
+            Створити дію
+          </button>
+          <button
+            className="btn tiny ghost"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleAdd("if");
+            }}
+          >
+            Створити розгалуження (if)
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
 
 function EdgesPanel({ schema, onAdd, onRemove }) {
   const [from, setFrom] = useState("");


### PR DESCRIPTION
## Summary
- replace add buttons with 10 placeholder slots per lane
- allow creating actions or IF branches from slot popup
- style slot placeholders and popup

## Testing
- `CI=true npm test -- --watch=false` *(fails: No tests found)*


------
https://chatgpt.com/codex/tasks/task_e_689e6f48bcac833288520bfa0e4687b0