### PR TITLE
style: reduce bp node title font

### DIFF
--- a/src/modules/businessProcesses/pages/BusinessProcessEditPage.css
+++ b/src/modules/businessProcesses/pages/BusinessProcessEditPage.css
@@ -124,6 +124,7 @@
   border-radius: 10px;
   padding: 6px 10px;
   text-align: center;
+  font-size: 11px;
 }
 
 .bp-node-flags {


### PR DESCRIPTION
## Summary
- set bp node title font size to 11px

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e6f4a679083329ef573968d927863