### PR TITLE
Draw business process edges as polylines

### DIFF
--- a/src/modules/businessProcesses/pages/BusinessProcessEditPage.css
+++ b/src/modules/businessProcesses/pages/BusinessProcessEditPage.css
@@ -169,14 +169,14 @@
   pointer-events: none;
 }
 
-.bp-edges-svg line {
+.bp-edges-svg polyline {
   stroke: #9ca3af;
-  stroke-width: 2px;
+  stroke-width: 1px;
 }
 
-.bp-edges-svg line.new { stroke: #16a34a; }
-.bp-edges-svg line.outdated { stroke: #7c3aed; }
-.bp-edges-svg line.problem { stroke: #dc2626; }
+.bp-edges-svg polyline.new { stroke: #16a34a; }
+.bp-edges-svg polyline.outdated { stroke: #7c3aed; }
+.bp-edges-svg polyline.problem { stroke: #dc2626; }
 
 .edges-panel {
   margin-top: 8px;

--- a/src/modules/businessProcesses/pages/BusinessProcessEditPage.jsx
+++ b/src/modules/businessProcesses/pages/BusinessProcessEditPage.jsx
@@ -87,12 +87,15 @@ export default function BusinessProcessEditPage() {
           const from = rects[e.from];
           const to = rects[e.to];
           if (!from || !to) return null;
+
+          const midX = (from.x + to.x) / 2;
           return {
             ...e,
             x1: from.x,
             y1: from.y,
             x2: to.x,
             y2: to.y,
+            points: `${from.x},${from.y} ${midX},${from.y} ${midX},${to.y} ${to.x},${to.y}`,
           };
         })
         .filter(Boolean);
@@ -442,14 +445,12 @@ export default function BusinessProcessEditPage() {
           </defs>
           {edgePaths.map((e) => (
             <g key={e.id} className={`edge ${e.kind}`}>
-              <line
+              <polyline
                 className={e.kind}
-                x1={e.x1}
-                y1={e.y1}
-                x2={e.x2}
-                y2={e.y2}
+                points={e.points}
+                fill="none"
                 stroke={EDGE_COLORS[e.kind] || EDGE_COLORS.default}
-                strokeWidth="2"
+                strokeWidth="1"
                 markerEnd={`url(#arrow-${e.kind})`}
               />
               {e.label ? (


### PR DESCRIPTION
## Summary
- render business process edges using polylines for horizontal-vertical-horizontal routes
- thin out edge stroke width

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e6f4b65e883329fcae2a0383beeec