### PR TITLE
Add Telegram-related migrations

### DIFF
--- a/backend/migrations/m20250815_143001_create_telegram_pending_groups_table.php
+++ b/backend/migrations/m20250815_143001_create_telegram_pending_groups_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%telegram_pending_groups}}`.
+ */
+class m20250815_143001_create_telegram_pending_groups_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        if ($this->db->getTableSchema('{{%telegram_pending_groups}}', true) === null) {
+            $this->createTable('{{%telegram_pending_groups}}', [
+                'id' => $this->primaryKey(),
+                'chat_id' => $this->bigInteger()->notNull()->unique(),
+                'title' => $this->string(255)->notNull(),
+                'invite_code' => $this->string(16)->notNull()->unique(),
+                'expires_at' => $this->dateTime()->notNull(),
+                'created_at' => $this->dateTime()->notNull(),
+            ]);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        if ($this->db->getTableSchema('{{%telegram_pending_groups}}', true) !== null) {
+            $this->dropTable('{{%telegram_pending_groups}}');
+        }
+    }
+}

--- a/backend/migrations/m20250815_143002_create_telegram_groups_table.php
+++ b/backend/migrations/m20250815_143002_create_telegram_groups_table.php
@@ -1,0 +1,63 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation or updating of table `{{%telegram_groups}}`.
+ */
+class m20250815_143002_create_telegram_groups_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $schema = $this->db->getTableSchema('{{%telegram_groups}}', true);
+        if ($schema === null) {
+            $this->createTable('{{%telegram_groups}}', [
+                'id' => $this->primaryKey(),
+                'company_id' => $this->integer()->null(),
+                'chat_id' => $this->bigInteger()->notNull()->unique(),
+                'title' => $this->string(255)->notNull(),
+                'is_active' => $this->tinyInteger(1)->defaultValue(0),
+                'linked_at' => $this->dateTime()->null(),
+                'created_at' => $this->dateTime()->notNull(),
+            ]);
+        } else {
+            $columns = $schema->columns;
+            if (!isset($columns['company_id'])) {
+                $this->addColumn('{{%telegram_groups}}', 'company_id', $this->integer()->null());
+            }
+            if (!isset($columns['chat_id'])) {
+                $this->addColumn('{{%telegram_groups}}', 'chat_id', $this->bigInteger()->notNull()->unique());
+            }
+            if (!isset($columns['title'])) {
+                $this->addColumn('{{%telegram_groups}}', 'title', $this->string(255)->notNull());
+            }
+            if (!isset($columns['is_active'])) {
+                $this->addColumn('{{%telegram_groups}}', 'is_active', $this->tinyInteger(1)->defaultValue(0));
+            }
+            if (!isset($columns['linked_at'])) {
+                $this->addColumn('{{%telegram_groups}}', 'linked_at', $this->dateTime()->null());
+            }
+            if (!isset($columns['created_at'])) {
+                $this->addColumn('{{%telegram_groups}}', 'created_at', $this->dateTime()->notNull());
+            }
+            try {
+                $this->createIndex('idx-telegram_groups-chat_id', '{{%telegram_groups}}', 'chat_id', true);
+            } catch (\yii\db\Exception $e) {
+                // index exists
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        if ($this->db->getTableSchema('{{%telegram_groups}}', true) !== null) {
+            $this->dropTable('{{%telegram_groups}}');
+        }
+    }
+}

--- a/backend/migrations/m20250815_143003_create_telegram_users_table.php
+++ b/backend/migrations/m20250815_143003_create_telegram_users_table.php
@@ -1,0 +1,95 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation or updating of table `{{%telegram_users}}`.
+ */
+class m20250815_143003_create_telegram_users_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $schema = $this->db->getTableSchema('{{%telegram_users}}', true);
+
+        if ($schema === null) {
+            // reuse telegram_aliases table if present
+            if ($this->db->getTableSchema('{{%telegram_aliases}}', true) !== null) {
+                $this->renameTable('{{%telegram_aliases}}', '{{%telegram_users}}');
+                $schema = $this->db->getTableSchema('{{%telegram_users}}', true);
+            }
+        }
+
+        if ($schema === null) {
+            $this->createTable('{{%telegram_users}}', [
+                'id' => $this->primaryKey(),
+                'company_id' => $this->integer()->notNull(),
+                'employee_id' => $this->integer()->null(),
+                'telegram_user_id' => $this->bigInteger()->notNull(),
+                'username' => $this->string(255),
+                'first_name' => $this->string(255),
+                'last_name' => $this->string(255),
+                'display_name' => $this->string(255),
+                'synonyms' => $this->json(),
+                'is_active' => $this->tinyInteger(1)->defaultValue(1),
+                'last_seen_at' => $this->dateTime()->null(),
+                'created_at' => $this->dateTime()->notNull(),
+            ]);
+            $this->createIndex('idx-telegram_users-company_user', '{{%telegram_users}}', ['company_id','telegram_user_id'], true);
+        } else {
+            $columns = $schema->columns;
+            if (!isset($columns['company_id'])) {
+                $this->addColumn('{{%telegram_users}}', 'company_id', $this->integer()->notNull());
+            }
+            if (!isset($columns['employee_id'])) {
+                $this->addColumn('{{%telegram_users}}', 'employee_id', $this->integer()->null());
+            }
+            if (!isset($columns['telegram_user_id'])) {
+                $this->addColumn('{{%telegram_users}}', 'telegram_user_id', $this->bigInteger()->notNull());
+            }
+            if (!isset($columns['username'])) {
+                $this->addColumn('{{%telegram_users}}', 'username', $this->string(255));
+            }
+            if (!isset($columns['first_name'])) {
+                $this->addColumn('{{%telegram_users}}', 'first_name', $this->string(255));
+            }
+            if (!isset($columns['last_name'])) {
+                $this->addColumn('{{%telegram_users}}', 'last_name', $this->string(255));
+            }
+            if (!isset($columns['display_name'])) {
+                $this->addColumn('{{%telegram_users}}', 'display_name', $this->string(255));
+            }
+            if (!isset($columns['synonyms'])) {
+                $this->addColumn('{{%telegram_users}}', 'synonyms', $this->json());
+            }
+            if (!isset($columns['is_active'])) {
+                $this->addColumn('{{%telegram_users}}', 'is_active', $this->tinyInteger(1)->defaultValue(1));
+            }
+            if (!isset($columns['last_seen_at'])) {
+                $this->addColumn('{{%telegram_users}}', 'last_seen_at', $this->dateTime()->null());
+            }
+            if (!isset($columns['created_at'])) {
+                $this->addColumn('{{%telegram_users}}', 'created_at', $this->dateTime()->notNull());
+            }
+            try {
+                $this->createIndex('idx-telegram_users-company_user', '{{%telegram_users}}', ['company_id','telegram_user_id'], true);
+            } catch (\yii\db\Exception $e) {
+                // index exists
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        if ($this->db->getTableSchema('{{%telegram_users}}', true) !== null) {
+            $this->dropTable('{{%telegram_users}}');
+        }
+        // cannot restore telegram_aliases table
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add `telegram_pending_groups` migration
- add `telegram_groups` migration and extend existing table if present
- add `telegram_users` migration, reusing `telegram_aliases` if found

## Testing
- `yii migrate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f43f484cc8332b9e2c2622597800c