### PR TITLE
feat: add telegram management page

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -172,6 +172,16 @@ POST /results/:id/complete — {"is_completed": true|false}
 Пагінація: бек повертає { items, pagination: { page, pageCount, pageSize, totalCount } }.
 На фронті використовуємо Pagination.jsx.
 
+Telegram
+POST /telegram/webhook — тіло: payload від Telegram (as-is). Відповідь: 200 OK.
+
+POST /telegram/link/by-code — { "invite_code", "company_id" } → { ok, chat_id, title }
+Помилки: 400 invalid_code, 410 code_expired, 409 already_linked
+
+GET /telegram/groups?company_id=ID → [{id, chat_id, title, is_active, linked_at}]
+GET /telegram/users?company_id=ID&q=olen → пагінований список користувачів
+PUT /telegram/users/{id} — { employee_id?, synonyms? }
+
 Потік авторизації у SPA
 Користувач заходить на /auth, логіниться (бек ставить cookie).
 

--- a/src/modules/telegram/pages/TelegramGroupPage.css
+++ b/src/modules/telegram/pages/TelegramGroupPage.css
@@ -1,0 +1,21 @@
+.telegram-page section {
+    margin-bottom: 40px;
+}
+
+.telegram-page .link-form {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.telegram-page table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.telegram-page table th,
+.telegram-page table td {
+    padding: 4px 8px;
+    border-bottom: 1px solid #ddd;
+}

--- a/src/modules/telegram/pages/TelegramGroupPage.jsx
+++ b/src/modules/telegram/pages/TelegramGroupPage.jsx
@@ -1,13 +1,295 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Layout from "../../../components/layout/Layout";
+import { useAuth } from "../../../context/AuthContext";
+import { useCompany } from "../../../context/CompanyContext";
+import api from "../../../services/api";
+import "./TelegramGroupPage.css";
 
 export default function TelegramGroupPage() {
+    const { user } = useAuth();
+    const { activeCompany, setActiveCompany } = useCompany();
+
+    const [inviteCode, setInviteCode] = useState("");
+    const [companyId, setCompanyId] = useState(activeCompany?.id || "");
+    const [groups, setGroups] = useState([]);
+    const [users, setUsers] = useState([]);
+    const [employees, setEmployees] = useState([]);
+
+    const companies = user?.companies || [];
+
+    useEffect(() => {
+        setCompanyId(activeCompany?.id || "");
+    }, [activeCompany]);
+
+    useEffect(() => {
+        if (!companyId) return;
+        loadGroups(companyId);
+        loadUsers(companyId);
+        loadEmployees(companyId);
+    }, [companyId]);
+
+    const loadGroups = async (cid) => {
+        try {
+            const { data } = await api.get(`/telegram/groups?company_id=${cid}`);
+            setGroups(data || []);
+        } catch (e) {
+            console.error("Помилка завантаження груп", e);
+        }
+    };
+
+    const loadUsers = async (cid) => {
+        try {
+            const { data } = await api.get(`/telegram/users?company_id=${cid}`);
+            const items = data?.items || data || [];
+            setUsers(
+                items.map((u) => ({
+                    ...u,
+                    synonymsInput: (u.synonyms || []).join(", "),
+                }))
+            );
+        } catch (e) {
+            console.error("Помилка завантаження користувачів", e);
+        }
+    };
+
+    const loadEmployees = async (cid) => {
+        try {
+            const { data } = await api.get(`/employees?company_id=${cid}`);
+            setEmployees(data || []);
+        } catch (e) {
+            console.error("Помилка завантаження співробітників", e);
+        }
+    };
+
+    const handleLink = async (e) => {
+        e.preventDefault();
+        try {
+            const { data } = await api.post("/telegram/link/by-code", {
+                invite_code: inviteCode,
+                company_id: Number(companyId),
+            });
+            window.dispatchEvent(
+                new CustomEvent("toast", {
+                    detail: {
+                        type: "success",
+                        message: `Групу прив'язано: ${data.title}`,
+                    },
+                })
+            );
+            setInviteCode("");
+            loadGroups(companyId);
+        } catch (err) {
+            console.error("Помилка прив'язки групи", err);
+        }
+    };
+
+    const refreshAdmins = async (id) => {
+        try {
+            await api.post(`/telegram/groups/${id}/refresh-admins`);
+            window.dispatchEvent(
+                new CustomEvent("toast", {
+                    detail: { type: "success", message: "Адмінів оновлено" },
+                })
+            );
+        } catch (e) {
+            console.error("Помилка оновлення адмінів", e);
+        }
+    };
+
+    const updateEmployee = async (id, employee_id) => {
+        try {
+            await api.put(`/telegram/users/${id}`, { employee_id });
+            setUsers((prev) =>
+                prev.map((u) =>
+                    u.id === id ? { ...u, employee_id } : u
+                )
+            );
+        } catch (e) {
+            console.error("Помилка оновлення працівника", e);
+        }
+    };
+
+    const handleSynonymsChange = (id, value) => {
+        setUsers((prev) =>
+            prev.map((u) =>
+                u.id === id ? { ...u, synonymsInput: value } : u
+            )
+        );
+    };
+
+    const saveSynonyms = async (id, value) => {
+        const synonyms = value
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+        try {
+            await api.put(`/telegram/users/${id}`, { synonyms });
+            setUsers((prev) =>
+                prev.map((u) =>
+                    u.id === id ? { ...u, synonyms } : u
+                )
+            );
+        } catch (e) {
+            console.error("Помилка збереження синонімів", e);
+        }
+    };
+
+    const onCompanyChange = (e) => {
+        const id = e.target.value;
+        setCompanyId(id);
+        const company = companies.find((c) => String(c.id) === id);
+        setActiveCompany(company || null);
+    };
+
     return (
         <Layout>
-            <h2>Телеграм група організації</h2>
-            <p>
-                Приєднуйтесь до нашого чату: <a href="https://t.me/finekogroup" target="_blank" rel="noreferrer">t.me/finekogroup</a>
-            </p>
+            <div className="telegram-page">
+                <h2>Telegram</h2>
+
+                <section>
+                    <h3>Прив'язка за кодом</h3>
+                    <form onSubmit={handleLink} className="link-form">
+                        <input
+                            type="text"
+                            value={inviteCode}
+                            onChange={(e) =>
+                                setInviteCode(e.target.value.toUpperCase())
+                            }
+                            placeholder="Код запрошення"
+                            required
+                        />
+                        <select
+                            value={companyId}
+                            onChange={onCompanyChange}
+                            required
+                        >
+                            <option value="">Оберіть компанію</option>
+                            {companies.map((c) => (
+                                <option key={c.id} value={c.id}>
+                                    {c.name}
+                                </option>
+                            ))}
+                        </select>
+                        <button className="btn primary" type="submit">
+                            Прив'язати
+                        </button>
+                    </form>
+                </section>
+
+                {companyId && (
+                    <>
+                        <section>
+                            <h3>Групи компанії</h3>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>Назва</th>
+                                        <th>chat_id</th>
+                                        <th>Статус</th>
+                                        <th>Дата прив'язки</th>
+                                        <th></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {groups.map((g) => (
+                                        <tr key={g.id}>
+                                            <td>{g.title}</td>
+                                            <td>{g.chat_id}</td>
+                                            <td>{g.is_active ? "активна" : ""}</td>
+                                            <td>{g.linked_at}</td>
+                                            <td>
+                                                <button
+                                                    className="btn"
+                                                    onClick={() =>
+                                                        refreshAdmins(g.id)
+                                                    }
+                                                >
+                                                    Оновити адмінів
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                    {groups.length === 0 && (
+                                        <tr>
+                                            <td colSpan="5">Немає груп</td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </section>
+
+                        <section>
+                            <h3>Користувачі Telegram (мапінг)</h3>
+                            <table className="table">
+                                <thead>
+                                    <tr>
+                                        <th>display_name</th>
+                                        <th>@username</th>
+                                        <th>telegram_user_id</th>
+                                        <th>employee</th>
+                                        <th>synonyms</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {users.map((u) => (
+                                        <tr key={u.id}>
+                                            <td>{u.display_name}</td>
+                                            <td>{u.username ? `@${u.username}` : ""}</td>
+                                            <td>{u.telegram_user_id}</td>
+                                            <td>
+                                                <select
+                                                    value={u.employee_id || ""}
+                                                    onChange={(e) =>
+                                                        updateEmployee(
+                                                            u.id,
+                                                            e.target.value || null
+                                                        )
+                                                    }
+                                                >
+                                                    <option value="">—</option>
+                                                    {employees.map((emp) => (
+                                                        <option
+                                                            key={emp.id}
+                                                            value={emp.id}
+                                                        >
+                                                            {emp.name ||
+                                                                emp.display_name}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                            </td>
+                                            <td>
+                                                <input
+                                                    type="text"
+                                                    value={u.synonymsInput || ""}
+                                                    onChange={(e) =>
+                                                        handleSynonymsChange(
+                                                            u.id,
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                    onBlur={(e) =>
+                                                        saveSynonyms(
+                                                            u.id,
+                                                            e.target.value
+                                                        )
+                                                    }
+                                                />
+                                            </td>
+                                        </tr>
+                                    ))}
+                                    {users.length === 0 && (
+                                        <tr>
+                                            <td colSpan="5">Немає користувачів</td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </section>
+                    </>
+                )}
+            </div>
         </Layout>
     );
 }
+


### PR DESCRIPTION
## Summary
- add Telegram page with group linking, company group list and user mapping
- document Telegram API endpoints

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f43cb1084833287db0e387e230d9d