### PR TITLE
Add invite code and Telegram reply services with webhook

### DIFF
--- a/public/api/telegramWebhook.php
+++ b/public/api/telegramWebhook.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../../services/InviteCodeService.php';
+require_once __DIR__ . '/../../services/TelegramReplyService.php';
+
+use Services\InviteCodeService;
+use Services\TelegramReplyService;
+
+$botToken = getenv('TELEGRAM_BOT_TOKEN');
+if (!$botToken) {
+    http_response_code(500);
+    echo 'Missing TELEGRAM_BOT_TOKEN';
+    exit;
+}
+
+$raw = file_get_contents('php://input');
+$update = json_decode($raw, true);
+if (!$update) {
+    http_response_code(400);
+    echo 'Invalid JSON';
+    exit;
+}
+
+$replyService = new TelegramReplyService($botToken);
+$inviteService = new InviteCodeService();
+
+if (isset($update['message'])) {
+    $message = $update['message'];
+    $chatId = $message['chat']['id'];
+    $text = $message['text'] ?? '';
+
+    if (preg_match('/^\/invite$/i', $text)) {
+        $code = $inviteService->generate();
+        $replyService->sendMessage($chatId, "Your invite code: $code", $message['message_id']);
+    }
+}

--- a/services/InviteCodeService.php
+++ b/services/InviteCodeService.php
@@ -1,0 +1,22 @@
+<?php
+namespace Services;
+
+class InviteCodeService
+{
+    private const CHARSET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+    /**
+     * Generate a random invite code of 6-8 characters using allowed charset.
+     */
+    public function generate(): string
+    {
+        $length = random_int(6, 8);
+        $characters = self::CHARSET;
+        $code = '';
+        $maxIndex = strlen($characters) - 1;
+        for ($i = 0; $i < $length; $i++) {
+            $code .= $characters[random_int(0, $maxIndex)];
+        }
+        return $code;
+    }
+}

--- a/services/TelegramReplyService.php
+++ b/services/TelegramReplyService.php
@@ -1,0 +1,49 @@
+<?php
+namespace Services;
+
+class TelegramReplyService
+{
+    private string $botToken;
+
+    public function __construct(string $botToken)
+    {
+        $this->botToken = $botToken;
+    }
+
+    /**
+     * Send a message through Telegram Bot API.
+     *
+     * @param int|string $chat_id
+     * @param string $text
+     * @param int|null $reply_to_message_id
+     *
+     * @return array Decoded JSON response from Telegram.
+     */
+    public function sendMessage($chat_id, string $text, ?int $reply_to_message_id = null): array
+    {
+        $url = "https://api.telegram.org/bot{$this->botToken}/sendMessage";
+        $params = [
+            'chat_id' => $chat_id,
+            'text' => $text,
+        ];
+        if ($reply_to_message_id !== null) {
+            $params['reply_to_message_id'] = $reply_to_message_id;
+        }
+
+        $options = [
+            'http' => [
+                'method' => 'POST',
+                'header' => "Content-Type: application/x-www-form-urlencoded\r\n",
+                'content' => http_build_query($params),
+            ],
+        ];
+
+        $context = stream_context_create($options);
+        $response = file_get_contents($url, false, $context);
+        if ($response === false) {
+            throw new \RuntimeException('Failed to send message to Telegram');
+        }
+
+        return json_decode($response, true);
+    }
+}


### PR DESCRIPTION
## Summary
- add InviteCodeService for generating invite codes
- add TelegramReplyService for sending replies to Telegram
- wire services into new API webhook endpoint

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689f43f69954833288a16b464baec28a