### PR TITLE
Add basic Telegram API helpers

### DIFF
--- a/src/modules/telegram/api/telegram.js
+++ b/src/modules/telegram/api/telegram.js
@@ -1,0 +1,17 @@
+import api from "../../../services/api";
+
+export const getPendingGroups = async () => (await api.get("/telegram/pending")).data;
+
+export const getCompanyGroups = async (companyId) => (
+    await api.get("/telegram/groups", { params: { company_id: companyId } })
+).data;
+
+export const searchCompanyUsers = async (companyId, q = "") => (
+    await api.get("/telegram/users", { params: { company_id: companyId, q } })
+).data;
+
+export default {
+    getPendingGroups,
+    getCompanyGroups,
+    searchCompanyUsers,
+};

--- a/src/modules/telegram/pages/TelegramGroupPage.jsx
+++ b/src/modules/telegram/pages/TelegramGroupPage.jsx
@@ -1,13 +1,36 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Layout from "../../../components/layout/Layout";
+import { getPendingGroups } from "../api/telegram";
 
 export default function TelegramGroupPage() {
+    const [pending, setPending] = useState([]);
+
+    useEffect(() => {
+        const load = async () => {
+            try {
+                const data = await getPendingGroups();
+                setPending(Array.isArray(data) ? data : []);
+            } catch (e) {
+                console.error("Failed to load telegram groups", e);
+            }
+        };
+        load();
+    }, []);
+
     return (
         <Layout>
             <h2>Телеграм група організації</h2>
-            <p>
-                Приєднуйтесь до нашого чату: <a href="https://t.me/finekogroup" target="_blank" rel="noreferrer">t.me/finekogroup</a>
-            </p>
+            {pending.length > 0 ? (
+                <ul>
+                    {pending.map((g) => (
+                        <li key={g.id || g.group_id}>{g.title || g.name}</li>
+                    ))}
+                </ul>
+            ) : (
+                <p>
+                    Приєднуйтесь до нашого чату: <a href="https://t.me/finekogroup" target="_blank" rel="noreferrer">t.me/finekogroup</a>
+                </p>
+            )}
         </Layout>
     );
 }


### PR DESCRIPTION
## Summary
- add API functions for pending groups, company groups and user search
- load pending groups on TelegramGroupPage

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f43f935188332ada0688fa59d2a8f