### PR TITLE
feat: expand telegram module with linking and list pages

### DIFF
--- a/src/modules/telegram/api/telegram.js
+++ b/src/modules/telegram/api/telegram.js
@@ -1,0 +1,13 @@
+import api from "../../../services/api";
+
+export const linkByCode = async (code) =>
+    (await api.post("/telegram/link/by-code", { code })).data;
+
+export const getPending = async () =>
+    (await api.get("/telegram/pending")).data;
+
+export const getGroups = async () =>
+    (await api.get("/telegram/groups")).data;
+
+export const getUsers = async () =>
+    (await api.get("/telegram/users")).data;

--- a/src/modules/telegram/components/GroupList.jsx
+++ b/src/modules/telegram/components/GroupList.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export default function GroupList({ groups = [] }) {
+    if (!groups.length) {
+        return <p>Груп немає</p>;
+    }
+
+    return (
+        <ul>
+            {groups.map((g) => (
+                <li key={g.id || g.link || g.username}>
+                    {g.title || g.name || g.username || g.id}
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/src/modules/telegram/components/InviteCodeForm.jsx
+++ b/src/modules/telegram/components/InviteCodeForm.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import { linkByCode } from "../api/telegram";
+
+export default function InviteCodeForm({ onLinked }) {
+    const [code, setCode] = useState("");
+    const [status, setStatus] = useState(null);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        try {
+            await linkByCode(code);
+            setStatus("Успішно");
+            setCode("");
+            if (onLinked) onLinked();
+        } catch (e) {
+            setStatus("Помилка");
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <input
+                type="text"
+                value={code}
+                placeholder="Код запрошення"
+                onChange={(e) => setCode(e.target.value)}
+            />
+            <button type="submit">Приєднатись</button>
+            {status && <div>{status}</div>}
+        </form>
+    );
+}

--- a/src/modules/telegram/components/PendingGroupList.jsx
+++ b/src/modules/telegram/components/PendingGroupList.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export default function PendingGroupList({ groups = [] }) {
+    if (!groups.length) {
+        return <p>Немає запрошень</p>;
+    }
+
+    return (
+        <ul>
+            {groups.map((g) => (
+                <li key={g.id || g.link || g.username}>
+                    {g.title || g.name || g.username || g.id}
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/src/modules/telegram/pages/TelegramGroupPage.jsx
+++ b/src/modules/telegram/pages/TelegramGroupPage.jsx
@@ -1,13 +1,41 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import Layout from "../../../components/layout/Layout";
+import GroupList from "../components/GroupList";
+import { getGroups } from "../api/telegram";
 
 export default function TelegramGroupPage() {
+    const [groups, setGroups] = useState([]);
+
+    useEffect(() => {
+        const fetch = async () => {
+            try {
+                const data = await getGroups();
+                setGroups(data || []);
+            } catch (e) {
+                setGroups([]);
+            }
+        };
+        fetch();
+    }, []);
+
     return (
         <Layout>
-            <h2>Телеграм група організації</h2>
-            <p>
-                Приєднуйтесь до нашого чату: <a href="https://t.me/finekogroup" target="_blank" rel="noreferrer">t.me/finekogroup</a>
-            </p>
+            <h2>Телеграм</h2>
+            <nav>
+                <ul>
+                    <li>
+                        <Link to="/telegram/link">Приєднатись за кодом</Link>
+                    </li>
+                    <li>
+                        <Link to="/telegram/groups">Групи</Link>
+                    </li>
+                    <li>
+                        <Link to="/telegram/users">Користувачі</Link>
+                    </li>
+                </ul>
+            </nav>
+            <GroupList groups={groups} />
         </Layout>
     );
 }

--- a/src/modules/telegram/pages/TelegramGroupsPage.jsx
+++ b/src/modules/telegram/pages/TelegramGroupsPage.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import Layout from "../../../components/layout/Layout";
+import GroupList from "../components/GroupList";
+import { getGroups } from "../api/telegram";
+
+export default function TelegramGroupsPage() {
+    const [groups, setGroups] = useState([]);
+
+    useEffect(() => {
+        const fetchGroups = async () => {
+            try {
+                const data = await getGroups();
+                setGroups(data || []);
+            } catch (e) {
+                setGroups([]);
+            }
+        };
+        fetchGroups();
+    }, []);
+
+    return (
+        <Layout>
+            <h2>Телеграм групи</h2>
+            <GroupList groups={groups} />
+        </Layout>
+    );
+}

--- a/src/modules/telegram/pages/TelegramLinkPage.jsx
+++ b/src/modules/telegram/pages/TelegramLinkPage.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from "react";
+import Layout from "../../../components/layout/Layout";
+import InviteCodeForm from "../components/InviteCodeForm";
+import PendingGroupList from "../components/PendingGroupList";
+import { getPending } from "../api/telegram";
+
+export default function TelegramLinkPage() {
+    const [pending, setPending] = useState([]);
+
+    const fetchPending = async () => {
+        try {
+            const data = await getPending();
+            setPending(data || []);
+        } catch (e) {
+            setPending([]);
+        }
+    };
+
+    useEffect(() => {
+        fetchPending();
+    }, []);
+
+    return (
+        <Layout>
+            <h2>Приєднання до Телеграм</h2>
+            <InviteCodeForm onLinked={fetchPending} />
+            <PendingGroupList groups={pending} />
+        </Layout>
+    );
+}

--- a/src/modules/telegram/pages/TelegramUsersPage.jsx
+++ b/src/modules/telegram/pages/TelegramUsersPage.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from "react";
+import Layout from "../../../components/layout/Layout";
+import { getUsers } from "../api/telegram";
+
+export default function TelegramUsersPage() {
+    const [users, setUsers] = useState([]);
+
+    useEffect(() => {
+        const fetchUsers = async () => {
+            try {
+                const data = await getUsers();
+                setUsers(data || []);
+            } catch (e) {
+                setUsers([]);
+            }
+        };
+        fetchUsers();
+    }, []);
+
+    return (
+        <Layout>
+            <h2>Телеграм користувачі</h2>
+            {users.length === 0 ? (
+                <p>Користувачів немає</p>
+            ) : (
+                <ul>
+                    {users.map((u) => (
+                        <li key={u.id || u.username}>
+                            {u.name || u.username || u.id}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </Layout>
+    );
+}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -12,6 +12,9 @@ import BpEditorPage from "../modules/bp/pages/BpEditorPage";
 import OrgPage from "../modules/org/pages/OrgPage";
 import Layout from "../components/layout/Layout";
 import TelegramGroupPage from "../modules/telegram/pages/TelegramGroupPage";
+import TelegramLinkPage from "../modules/telegram/pages/TelegramLinkPage";
+import TelegramGroupsPage from "../modules/telegram/pages/TelegramGroupsPage";
+import TelegramUsersPage from "../modules/telegram/pages/TelegramUsersPage";
 import InstructionsPage from "../modules/instructions/pages/InstructionsPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
 import ForgotPasswordPage from "../modules/auth/pages/ForgotPasswordPage";
@@ -131,6 +134,30 @@ export default function AppRouter() {
                     element={
                         <RequireAuth>
                             <TelegramGroupPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/telegram/link"
+                    element={
+                        <RequireAuth>
+                            <TelegramLinkPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/telegram/groups"
+                    element={
+                        <RequireAuth>
+                            <TelegramGroupsPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/telegram/users"
+                    element={
+                        <RequireAuth>
+                            <TelegramUsersPage />
                         </RequireAuth>
                     }
                 />


### PR DESCRIPTION
## Summary
- add telegram API client with link, pending, groups, users endpoints
- create invite code form, pending-group list, and group list components
- introduce pages for linking telegram, viewing groups and users; update group page with navigation
- wire new pages into router

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f43fa01e083329d57379c0836cab1