### PR TITLE
feat: fetch telegram group counts

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -3,6 +3,7 @@ import Header from "./Header/Header";
 import Sidebar, { RightSidebar } from "./Sidebar/Sidebar";
 import Footer from "./Footer/Footer";
 import "./Layout.css";
+import useTelegramCounts from "../../modules/telegram/hooks/useTelegramCounts";
 
 const LEFT_KEY = "layout:left";
 const RIGHT_KEY = "layout:right";
@@ -10,6 +11,7 @@ const RIGHT_KEY = "layout:right";
 export default function Layout({ children }) {
     const [leftOpen, setLeftOpen] = useState(false);
     const [rightOpen, setRightOpen] = useState(false);
+    const { groups: telegramGroups } = useTelegramCounts();
 
     const toggleLeft = useCallback(() => {
         setLeftOpen((prev) => {
@@ -63,7 +65,7 @@ export default function Layout({ children }) {
                 isOpen={leftOpen}
                 onToggle={toggleLeft}
                 resultsCount={3}
-                telegramCount={2}
+                telegramCount={telegramGroups}
             />
             <div className="layout-column">
                 <Header />

--- a/src/modules/telegram/hooks/useTelegramCounts.js
+++ b/src/modules/telegram/hooks/useTelegramCounts.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import api from "../../../services/api";
+
+export default function useTelegramCounts() {
+    const [counts, setCounts] = useState({ groups: 0, users: 0 });
+
+    useEffect(() => {
+        let ignore = false;
+
+        const fetchCounts = async () => {
+            try {
+                const { data } = await api.get("/telegram/groups");
+
+                let groups = 0;
+                let users = 0;
+
+                if (Array.isArray(data)) {
+                    groups = data.length;
+                    users = data.reduce((sum, g) => {
+                        if (g) {
+                            const u = g.users?.length || g.users_count || g.user_count || 0;
+                            return sum + (typeof u === "number" ? u : 0);
+                        }
+                        return sum;
+                    }, 0);
+                } else if (data) {
+                    groups = data.groups ?? data.groupCount ?? data.total ?? 0;
+                    users = data.users ?? data.userCount ?? 0;
+                }
+
+                if (!ignore) {
+                    setCounts({ groups, users });
+                }
+            } catch (e) {
+                if (!ignore) {
+                    setCounts({ groups: 0, users: 0 });
+                }
+            }
+        };
+
+        fetchCounts();
+
+        return () => {
+            ignore = true;
+        };
+    }, []);
+
+    return counts;
+}


### PR DESCRIPTION
## Summary
- add `useTelegramCounts` hook to retrieve telegram group/user totals
- use hook in `Layout` to display telegram badge dynamically

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f43fa953c83328eb7e9887bdaf51d