### PR TITLE
feat: add telegram bot token config

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -254,8 +254,11 @@ RTK Query/React Query для кешу списків (коли з’являть
 ```js
 const config = {
   apiBaseUrl: "https://api.tasks.fineko.space",
-  // telegramBotToken: "...",
+  telegramBotToken: "", // токен бота Telegram (необов'язково)
   // threadsApiKey: "...",
 };
 
 export default config;
+```
+
+`telegramBotToken` береться з `REACT_APP_TELEGRAM_BOT_TOKEN` або `window.__TELEGRAM_BOT_TOKEN__` і може залишатися порожнім, якщо бот не використовується.

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -15,8 +15,19 @@ const raw = fromEnv || fromWindow || "https://api.tasks.fineko.space";
 // Приберемо кінцеві слеші, щоб не було // у запитах
 export const API_BASE_URL = raw.replace(/\/+$/, "");
 
+// Telegram Bot Token (за потреби)
+const telegramBotTokenEnv = (
+    process.env.REACT_APP_TELEGRAM_BOT_TOKEN || ""
+).trim();
+const telegramBotTokenWindow =
+    typeof window !== "undefined" && window.__TELEGRAM_BOT_TOKEN__
+        ? String(window.__TELEGRAM_BOT_TOKEN__).trim()
+        : "";
+export const TELEGRAM_BOT_TOKEN =
+    telegramBotTokenEnv || telegramBotTokenWindow || "";
+
 // Можеш додати тут інші конфіги за потреби, напр. таймаути тощо.
 // export const REQUEST_TIMEOUT_MS = 20000;
 
-const env = { API_BASE_URL };
+const env = { API_BASE_URL, telegramBotToken: TELEGRAM_BOT_TOKEN };
 export default env;


### PR DESCRIPTION
## Summary
- expose Telegram bot token in env configuration
- describe telegramBotToken in architecture docs

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f43fb56c483329a076553edfa45cd