### PR TITLE
feat: support telegram auth callback

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -23,6 +23,15 @@ export function AuthProvider({ children }) {
     // опційно редірект на /login
   };
 
+  const telegramLogin = async (token) => {
+    const { data } = await api.post("/auth/telegram", { token });
+    localStorage.setItem("access_token", data.access_token);
+    localStorage.setItem("refresh_token", data.refresh_token);
+    localStorage.setItem("user", JSON.stringify(data.user));
+    setUser(data.user);
+    return data.user;
+  };
+
   useEffect(() => {
     const storedUser = localStorage.getItem("user");
     if (storedUser) {
@@ -63,7 +72,7 @@ export function AuthProvider({ children }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, logout, telegramLogin }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/modules/auth/pages/LoginPage.jsx
+++ b/src/modules/auth/pages/LoginPage.jsx
@@ -56,12 +56,7 @@ export default function LoginPage() {
                 <button
                     type="button"
                     className="telegram-btn"
-                    onClick={() =>
-                        window.open(
-                            "https://t.me/finekobot?start=login",
-                            "_blank"
-                        )
-                    }
+                    onClick={() => navigate("/auth/telegram")}
                 >
                     Увійти через Telegram
                 </button>

--- a/src/modules/auth/pages/TelegramAuthPage.jsx
+++ b/src/modules/auth/pages/TelegramAuthPage.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useAuth } from "../../../context/AuthContext";
+
+export default function TelegramAuthPage() {
+    const { telegramLogin } = useAuth();
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+        let token = params.get("token") || params.get("jwt");
+        if (!token && location.hash) {
+            const hashParams = new URLSearchParams(location.hash.slice(1));
+            token = hashParams.get("token") || hashParams.get("jwt");
+        }
+        if (token) {
+            telegramLogin(token)
+                .then(() => navigate("/tasks"))
+                .catch(() => navigate("/auth"));
+        } else {
+            window.open("https://t.me/finekobot?start=login", "_blank");
+        }
+    }, [location, telegramLogin, navigate]);
+
+    return <div>Зачекайте, авторизація через Telegram...</div>;
+}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -16,6 +16,7 @@ import InstructionsPage from "../modules/instructions/pages/InstructionsPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
 import ForgotPasswordPage from "../modules/auth/pages/ForgotPasswordPage";
 import ResetPasswordPage from "../modules/auth/pages/ResetPasswordPage";
+import TelegramAuthPage from "../modules/auth/pages/TelegramAuthPage";
 import NotFound from "../pages/NotFound";
 
 import { useAuth } from "../context/AuthContext";
@@ -33,6 +34,7 @@ export default function AppRouter() {
                 <Route path="/auth" element={<LoginPage />} />
                 <Route path="/auth/forgot" element={<ForgotPasswordPage />} />
                 <Route path="/auth/reset/:token" element={<ResetPasswordPage />} />
+                <Route path="/auth/telegram" element={<TelegramAuthPage />} />
 
                 {/* Приватні */}
                 <Route


### PR DESCRIPTION
## Summary
- add telegramLogin helper to auth context and expose in provider
- create TelegramAuthPage to handle telegram login tokens
- link login page telegram button to new route and register route in router

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f43fd811c8332a596799076d92023