### PR TITLE
Add Telegram pending groups page

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -3,6 +3,7 @@ import Header from "./Header/Header";
 import Sidebar, { RightSidebar } from "./Sidebar/Sidebar";
 import Footer from "./Footer/Footer";
 import "./Layout.css";
+import api from "../../services/api";
 
 const LEFT_KEY = "layout:left";
 const RIGHT_KEY = "layout:right";
@@ -10,6 +11,7 @@ const RIGHT_KEY = "layout:right";
 export default function Layout({ children }) {
     const [leftOpen, setLeftOpen] = useState(false);
     const [rightOpen, setRightOpen] = useState(false);
+    const [telegramCount, setTelegramCount] = useState(0);
 
     const toggleLeft = useCallback(() => {
         setLeftOpen((prev) => {
@@ -57,13 +59,23 @@ export default function Layout({ children }) {
         };
     }, [toggleLeft, toggleRight]);
 
+    useEffect(() => {
+        api
+            .get("/telegram/pending")
+            .then((res) => {
+                const data = Array.isArray(res.data) ? res.data : [];
+                setTelegramCount(data.length);
+            })
+            .catch(() => {});
+    }, []);
+
     return (
         <div className={`layout ${leftOpen ? "left-open" : ""} ${rightOpen ? "right-open" : ""}`}>
             <Sidebar
                 isOpen={leftOpen}
                 onToggle={toggleLeft}
                 resultsCount={3}
-                telegramCount={2}
+                telegramCount={telegramCount}
             />
             <div className="layout-column">
                 <Header />

--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -189,9 +189,25 @@ export default function Sidebar({
                             >
                                 <FiSend className="menu-icon" />
                                 {isOpen && (
+                                    <span className="menu-text">
+                                        Телеграм
+                                    </span>
+                                )}
+                            </NavLink>
+                        </li>
+                        <li>
+                            <NavLink
+                                to="/telegram/pending"
+                                className={({ isActive }) =>
+                                    isActive ? "active" : ""
+                                }
+                                onClick={handleNavClick}
+                            >
+                                <FiGitBranch className="menu-icon" />
+                                {isOpen && (
                                     <>
                                         <span className="menu-text">
-                                            Телеграм
+                                            Заявки Telegram
                                         </span>
                                         <span className="badge menu-badge">
                                             {telegramCount}

--- a/src/modules/telegram/pages/PendingGroupsPage.jsx
+++ b/src/modules/telegram/pages/PendingGroupsPage.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from "react";
+import Layout from "../../../components/layout/Layout";
+import api from "../../../services/api";
+
+export default function PendingGroupsPage() {
+    const [groups, setGroups] = useState([]);
+
+    useEffect(() => {
+        api
+            .get("/telegram/pending")
+            .then((res) => {
+                const data = Array.isArray(res.data) ? res.data : [];
+                setGroups(data);
+            })
+            .catch((err) => {
+                console.error("Не вдалося завантажити групи:", err);
+            });
+    }, []);
+
+    const maskCode = (code = "") => {
+        if (!code) return "";
+        return `${code.slice(0, 2)}****`;
+    };
+
+    return (
+        <Layout>
+            <h2>Заявки на Telegram групи</h2>
+            {groups.length === 0 ? (
+                <p>Немає заявок</p>
+            ) : (
+                <table className="table">
+                    <thead>
+                        <tr>
+                            <th>Група</th>
+                            <th>Код запрошення</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {groups.map((g) => (
+                            <tr key={g.id || g.group_id}>
+                                <td>{g.title || g.name || g.group_title}</td>
+                                <td>{maskCode(g.invite_code || g.inviteCode)}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+        </Layout>
+    );
+}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -12,6 +12,7 @@ import BpEditorPage from "../modules/bp/pages/BpEditorPage";
 import OrgPage from "../modules/org/pages/OrgPage";
 import Layout from "../components/layout/Layout";
 import TelegramGroupPage from "../modules/telegram/pages/TelegramGroupPage";
+import PendingGroupsPage from "../modules/telegram/pages/PendingGroupsPage";
 import InstructionsPage from "../modules/instructions/pages/InstructionsPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
 import ForgotPasswordPage from "../modules/auth/pages/ForgotPasswordPage";
@@ -131,6 +132,14 @@ export default function AppRouter() {
                     element={
                         <RequireAuth>
                             <TelegramGroupPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/telegram/pending"
+                    element={
+                        <RequireAuth>
+                            <PendingGroupsPage />
                         </RequireAuth>
                     }
                 />


### PR DESCRIPTION
## Summary
- add pending Telegram groups page that lists results from `/telegram/pending` with masked invite codes
- wire up new route and sidebar navigation entry with pending count badge
- load pending group count in layout for sidebar badge

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f43ffa7008332bd35c72eec088307