### PR TITLE
feat: improve add task form with labels and executor

### DIFF
--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -158,9 +158,25 @@
   margin-bottom: 16px;
 }
 
+.add-task-form .at-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.add-task-form .at-field.full-width {
+  flex: 1 1 100%;
+}
+
+.add-task-form .at-field span {
+  font-size: 14px;
+}
+
 .add-task-form input,
 .add-task-form select,
 .add-task-form textarea {
+  width: 100%;
   padding: 4px 8px;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);


### PR DESCRIPTION
## Summary
- label all fields in add task form and show current user's full name as assigner
- add executor dropdown with available users and send executor id when creating tasks
- ensure results and templates dropdowns display real entities

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f69a53230833289ae724d75fc0143