### PR TITLE
feat: secure pending telegram groups

### DIFF
--- a/backend/controllers/TelegramController.php
+++ b/backend/controllers/TelegramController.php
@@ -29,8 +29,9 @@ class TelegramController extends Controller
         ];
     }
 
-    public function actionPending()
+    public function actionPending($company_id)
     {
+        $this->checkCompanyAccess($company_id);
         $items = TelegramPendingGroups::find()->asArray()->all();
         foreach ($items as &$item) {
             if (isset($item['invite_code'])) {


### PR DESCRIPTION
## Summary
- protect pending Telegram groups endpoint with company-level access check

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689f6ab36c348332aac611e13a1284a7