### PR TITLE
feat: add telegram management pages

### DIFF
--- a/src/modules/telegram/api/telegram.js
+++ b/src/modules/telegram/api/telegram.js
@@ -33,12 +33,3 @@ export const refreshGroupAdmins = async (id) => {
     const r = await api.post(`/telegram/groups/${id}/refresh-admins`);
     return r.data;
 };
-
-export default {
-    linkGroupByCode,
-    fetchPendingGroups,
-    fetchGroups,
-    fetchUsers,
-    updateUser,
-    refreshGroupAdmins,
-};


### PR DESCRIPTION
## Summary
- refactor Telegram API to use named exports
- document Telegram linking, group, and user management pages

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f6b00ba808332bda43da648f1a935