### PR TITLE
feat: add telegram groups management page

### DIFF
--- a/src/modules/telegram/api/telegram.js
+++ b/src/modules/telegram/api/telegram.js
@@ -33,3 +33,23 @@ export const refreshGroupAdmins = async (id) => {
     const r = await api.post(`/telegram/groups/${id}/refresh-admins`);
     return r.data;
 };
+
+export const fetchGroup = async (id) => {
+    const r = await api.get(`/telegram/groups/${id}`);
+    return r.data;
+};
+
+export const updateGroup = async (id, payload) => {
+    const r = await api.patch(`/telegram/groups/${id}`, payload);
+    return r.data;
+};
+
+export const deleteGroup = async (id) => {
+    const r = await api.delete(`/telegram/groups/${id}`);
+    return r.data;
+};
+
+export const updateGroupMembers = async (id, members) => {
+    const r = await api.patch(`/telegram/groups/${id}/members`, { members });
+    return r.data;
+};

--- a/src/modules/telegram/components/TelegramGroupDetails.css
+++ b/src/modules/telegram/components/TelegramGroupDetails.css
@@ -1,0 +1,34 @@
+.tg-group-details {
+    border: 1px solid #ddd;
+    padding: 16px;
+    margin-top: 20px;
+}
+
+.tg-group-details__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.tg-group-details__field {
+    margin-bottom: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.tg-group-details__members table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.tg-group-details__members th,
+.tg-group-details__members td {
+    padding: 4px 8px;
+    border-bottom: 1px solid #ddd;
+}
+
+.tg-group-details__stats {
+    margin-top: 16px;
+}

--- a/src/modules/telegram/components/TelegramGroupDetails.jsx
+++ b/src/modules/telegram/components/TelegramGroupDetails.jsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from "react";
+import {
+    fetchGroup,
+    updateGroup,
+    updateGroupMembers,
+} from "../api/telegram";
+import "./TelegramGroupDetails.css";
+
+export default function TelegramGroupDetails({ groupId, onClose }) {
+    const [group, setGroup] = useState(null);
+    const [name, setName] = useState("");
+
+    useEffect(() => {
+        if (!groupId) return;
+        let ignore = false;
+        const load = async () => {
+            try {
+                const data = await fetchGroup(groupId);
+                if (!ignore) {
+                    setGroup(data);
+                    setName(data.title || "");
+                }
+            } catch (e) {
+                console.error("Помилка завантаження групи", e);
+            }
+        };
+        load();
+        return () => {
+            ignore = true;
+        };
+    }, [groupId]);
+
+    const saveName = async () => {
+        try {
+            await updateGroup(groupId, { title: name });
+            setGroup((prev) => ({ ...prev, title: name }));
+        } catch (e) {
+            console.error("Помилка оновлення назви", e);
+        }
+    };
+
+    const changeRole = async (memberId, role) => {
+        try {
+            await updateGroupMembers(groupId, [{ id: memberId, role }]);
+            setGroup((prev) => ({
+                ...prev,
+                members: prev.members.map((m) =>
+                    (m.id === memberId || m.user_id === memberId)
+                        ? { ...m, role }
+                        : m
+                ),
+            }));
+        } catch (e) {
+            console.error("Помилка оновлення ролі", e);
+        }
+    };
+
+    if (!group) return null;
+
+    const members = group.members || group.users || [];
+
+    return (
+        <div className="tg-group-details">
+            <div className="tg-group-details__header">
+                <h3>Деталі групи</h3>
+                {onClose && (
+                    <button className="btn small" onClick={onClose}>
+                        Закрити
+                    </button>
+                )}
+            </div>
+            <div className="tg-group-details__field">
+                <label>Назва</label>
+                <input
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    onBlur={saveName}
+                />
+            </div>
+            <div className="tg-group-details__field">
+                <label>Telegram ID</label>
+                <span>{group.chat_id}</span>
+            </div>
+            <div className="tg-group-details__members">
+                <h4>Учасники</h4>
+                <table className="table">
+                    <thead>
+                        <tr>
+                            <th>Нік</th>
+                            <th>Ім'я</th>
+                            <th>Роль</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {members.map((m) => {
+                            const id = m.id || m.user_id || m.telegram_user_id;
+                            return (
+                                <tr key={id}>
+                                    <td>{m.username ? `@${m.username}` : ""}</td>
+                                    <td>{m.name || m.first_name || m.display_name}</td>
+                                    <td>
+                                        <select
+                                            value={m.role || "member"}
+                                            onChange={(e) => changeRole(id, e.target.value)}
+                                        >
+                                            <option value="member">Учасник</option>
+                                            <option value="manager">Постановник</option>
+                                            <option value="admin">Адмін</option>
+                                        </select>
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                        {members.length === 0 && (
+                            <tr>
+                                <td colSpan="3">Немає учасників</td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
+            </div>
+            {group.stats && (
+                <div className="tg-group-details__stats">
+                    <p>Задач створено: {group.stats.tasks}</p>
+                    <p>Результатів створено: {group.stats.results}</p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/modules/telegram/components/TelegramGroupList.jsx
+++ b/src/modules/telegram/components/TelegramGroupList.jsx
@@ -1,31 +1,67 @@
 import React from "react";
 
-export default function TelegramGroupList({ groups = [], onRefreshAdmins }) {
+export default function TelegramGroupList({
+    groups = [],
+    onSelect,
+    onRemove,
+    onRefreshAdmins,
+}) {
     return (
-        <table className="table">
+        <table className="table telegram-group-list">
             <thead>
                 <tr>
                     <th>Назва</th>
-                    <th>chat_id</th>
+                    <th>Telegram ID</th>
+                    <th>Дата підключення</th>
+                    <th>Учасники</th>
                     <th>Статус</th>
-                    <th>Дата прив'язки</th>
-                    <th></th>
+                    <th>Дії</th>
                 </tr>
             </thead>
             <tbody>
                 {groups.map((g) => (
-                    <tr key={g.id}>
+                    <tr
+                        key={g.id}
+                        onClick={() => onSelect && onSelect(g)}
+                        className="telegram-group-list__row"
+                    >
                         <td>{g.title}</td>
                         <td>{g.chat_id}</td>
-                        <td>{g.is_active ? "активна" : ""}</td>
                         <td>{g.linked_at}</td>
+                        <td>{g.users_count || g.user_count || 0}</td>
+                        <td>{g.is_active ? "активна" : "неактивна"}</td>
                         <td>
                             {onRefreshAdmins && (
                                 <button
-                                    className="btn"
-                                    onClick={() => onRefreshAdmins(g.id)}
+                                    className="btn small"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onRefreshAdmins(g.id);
+                                    }}
                                 >
                                     Оновити адмінів
+                                </button>
+                            )}
+                            {onSelect && (
+                                <button
+                                    className="btn small"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onSelect(g);
+                                    }}
+                                >
+                                    Відкрити
+                                </button>
+                            )}
+                            {onRemove && (
+                                <button
+                                    className="btn small danger"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onRemove(g.id);
+                                    }}
+                                >
+                                    Відключити
                                 </button>
                             )}
                         </td>
@@ -33,7 +69,7 @@ export default function TelegramGroupList({ groups = [], onRefreshAdmins }) {
                 ))}
                 {groups.length === 0 && (
                     <tr>
-                        <td colSpan="5">Немає груп</td>
+                        <td colSpan="6">Немає груп</td>
                     </tr>
                 )}
             </tbody>

--- a/src/modules/telegram/pages/TelegramGroupPage.css
+++ b/src/modules/telegram/pages/TelegramGroupPage.css
@@ -2,6 +2,26 @@
     margin-bottom: 40px;
 }
 
+.telegram-page__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+.telegram-page__body {
+    display: flex;
+    gap: 24px;
+}
+
+.telegram-page__main {
+    flex: 1;
+}
+
+.telegram-page__aside {
+    width: 300px;
+}
+
 .telegram-page .link-form {
     display: flex;
     gap: 8px;
@@ -18,4 +38,21 @@
 .telegram-page table td {
     padding: 4px 8px;
     border-bottom: 1px solid #ddd;
+}
+
+.telegram-group-list__row {
+    cursor: pointer;
+}
+
+.fab {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
 }


### PR DESCRIPTION
## Summary
- add api helpers for telegram group details and member roles
- implement detailed telegram group view with role editing
- integrate group linking and management into Telegram groups page

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b87fc492bc8332aa126921be479c97