### PR TITLE
feat: add results column to templates page

### DIFF
--- a/src/modules/templates/pages/TemplatesPage.css
+++ b/src/modules/templates/pages/TemplatesPage.css
@@ -1,9 +1,43 @@
 @import "../../../styles/variables.css";
 
+
 .templates-page {
   display: grid;
-  gap: 12px;
+  grid-template-columns: 1fr 260px;
+  gap: 16px;
   padding: 16px;
+  align-items: flex-start;
+}
+
+.tp-main {
+  display: grid;
+  gap: 12px;
+}
+
+.tp-side {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tp-results-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+}
+
+.tp-result {
+  padding: 8px;
+  text-align: left;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-sm);
+  background: #fff;
+  cursor: pointer;
+}
+
+.tp-result:hover {
+  background: var(--bg-soft);
 }
 
 .tp-head {
@@ -142,6 +176,9 @@
 }
 
 @media (max-width: 860px) {
+  .templates-page {
+    grid-template-columns: 1fr;
+  }
   .tp-row {
     grid-template-columns: 1.5fr 1.5fr 1fr auto;
   }

--- a/src/modules/templates/pages/TemplatesPage.jsx
+++ b/src/modules/templates/pages/TemplatesPage.jsx
@@ -132,6 +132,16 @@ export default function TemplatesPage() {
     setModalOpen(true);
   };
 
+  const openCreateFromResult = (result) => {
+    setForm({
+      id: null,
+      name: result?.title || "",
+      flags: { ...defaultFlags },
+      payload: { ...defaultPayload, resultId: result?.id || "" },
+    });
+    setModalOpen(true);
+  };
+
   const openEdit = (t) => {
     setForm({
       id: t.id,
@@ -233,234 +243,247 @@ export default function TemplatesPage() {
   return (
     <Layout>
       <div className="templates-page">
-        <div className="tp-head">
-          <h1>Шаблони</h1>
-          <div className="tp-actions">
-            <input
-              className="input"
-              placeholder="Пошук за назвою…"
-              value={q}
-              onChange={(e) => setQ(e.target.value)}
-            />
-            <button className="btn primary" onClick={openCreate}>
-              + Новий шаблон
-            </button>
+        <div className="tp-main">
+          <div className="tp-head">
+            <h1>Шаблони</h1>
+            <div className="tp-actions">
+              <input
+                className="input"
+                placeholder="Пошук за назвою…"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+              />
+              <button className="btn primary" onClick={openCreate}>
+                + Новий шаблон
+              </button>
+            </div>
           </div>
-        </div>
 
-        {error && <div className="tp-error">{error}</div>}
+          {error && <div className="tp-error">{error}</div>}
 
-        <div className="tp-table card">
-          <div className="tp-row tp-row--head">
-            <div className="c-name">Назва</div>
-            <div className="c-flags">Що зберігає</div>
-            <div className="c-meta">Оновлено</div>
-            <div className="c-actions">Дії</div>
+          <div className="tp-table card">
+            <div className="tp-row tp-row--head">
+              <div className="c-name">Назва</div>
+              <div className="c-flags">Що зберігає</div>
+              <div className="c-meta">Оновлено</div>
+              <div className="c-actions">Дії</div>
+            </div>
+            {loading ? (
+              <div className="tp-empty">Завантаження…</div>
+            ) : filtered.length ? (
+              filtered.map((t) => (
+                <div key={t.id} className="tp-row">
+                  <div className="c-name">{t.name}</div>
+                  <div className="c-flags"><FlagsBadge flags={t.flags} /></div>
+                  <div className="c-meta">
+                    {t.updated_at
+                      ? new Date(t.updated_at * 1000).toLocaleString()
+                      : "—"}
+                  </div>
+                  <div className="c-actions">
+                    <RowActions
+                      busy={busyId === t.id}
+                      onEdit={() => openEdit(t)}
+                      onDelete={() => onDelete(t.id)}
+                    />
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="tp-empty">Поки що немає шаблонів</div>
+            )}
           </div>
-          {loading ? (
-            <div className="tp-empty">Завантаження…</div>
-          ) : filtered.length ? (
-            filtered.map((t) => (
-              <div key={t.id} className="tp-row">
-                <div className="c-name">{t.name}</div>
-                <div className="c-flags"><FlagsBadge flags={t.flags} /></div>
-                <div className="c-meta">
-                  {t.updated_at
-                    ? new Date(t.updated_at * 1000).toLocaleString()
-                    : "—"}
+
+          {modalOpen && (
+            <div className="tp-modal">
+              <div className="tp-modal__dialog card">
+                <div className="tp-modal__head">
+                  <h2>{form.id ? "Редагувати шаблон" : "Новий шаблон"}</h2>
+                  <button className="btn xs ghost" onClick={() => setModalOpen(false)}>✖</button>
                 </div>
-                <div className="c-actions">
-                  <RowActions
-                    busy={busyId === t.id}
-                    onEdit={() => openEdit(t)}
-                    onDelete={() => onDelete(t.id)}
-                  />
-                </div>
+
+                <form onSubmit={onSubmit} className="tp-modal__body">
+                  <VoiceInput endpoint="/templates/voice" onResult={handleVoiceTemplate} />
+                  <label className="field">
+                    <span>Назва шаблону*</span>
+                    <input
+                      className="input"
+                      value={form.name}
+                      onChange={(e) => setForm((s) => ({ ...s, name: e.target.value }))}
+                      placeholder="Наприклад: Щоденний результат"
+                      required
+                    />
+                  </label>
+
+                  <div className="group">
+                    <div className="group-title">Значення полів</div>
+
+                        <label className="field">
+                          <span>Назва задачі</span>
+                          <input
+                            className="input"
+                            value={form.payload.title}
+                            onChange={(e) => setPayload("title", e.target.value)}
+                          />
+                        </label>
+
+                        <label className="field">
+                          <span>Очікуваний результат</span>
+                          <textarea
+                            className="input"
+                            rows={3}
+                            value={form.payload.expected_result}
+                            onChange={(e) => setPayload("expected_result", e.target.value)}
+                          />
+                        </label>
+
+                        <label className="field">
+                          <span>Результат</span>
+                          <input
+                            className="input"
+                            value={form.payload.result}
+                            onChange={(e) => setPayload("result", e.target.value)}
+                          />
+                        </label>
+
+                        <label className="field">
+                          <span>Тип</span>
+                          <select
+                            className="input"
+                            value={form.payload.type}
+                            onChange={(e) => setPayload("type", e.target.value)}
+                          >
+                            <option value="важлива термінова">Важлива - термінова</option>
+                            <option value="важлива нетермінова">Важлива - не термінова</option>
+                            <option value="неважлива термінова">Неважлива - термінова</option>
+                            <option value="неважлива нетермінова">Неважлива - нетермінова</option>
+                          </select>
+                        </label>
+
+                    <div className="row2">
+                          <label className="field">
+                            <span>Запланований час</span>
+                            <input
+                              className="input"
+                              type="time"
+                              value={form.payload.planned_time}
+                              onChange={(e) => setPayload("planned_time", e.target.value)}
+                            />
+                          </label>
+
+                          <label className="field">
+                            <span>Фактичний час</span>
+                            <input
+                              className="input"
+                              type="time"
+                              value={form.payload.actual_time}
+                              onChange={(e) => setPayload("actual_time", e.target.value)}
+                            />
+                          </label>
+                        </div>
+
+                        <label className="field">
+                          <span>Хто назначив</span>
+                          <input
+                            className="input"
+                            value={form.payload.manager}
+                            onChange={(e) => setPayload("manager", e.target.value)}
+                          />
+                        </label>
+
+                        <label className="field">
+                          <span>Коментарі</span>
+                          <input
+                            className="input"
+                            value={form.payload.comments}
+                            onChange={(e) => setPayload("comments", e.target.value)}
+                          />
+                        </label>
+
+                        <label className="field">
+                          <span>Результат</span>
+                          <select
+                            className="input"
+                            value={form.payload.resultId}
+                            onChange={(e) => setPayload("resultId", e.target.value)}
+                          >
+                            <option value="">—</option>
+                            {results.map((r) => (
+                              <option key={r.id} value={r.id}>
+                                {r.title}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+
+                        <div className="row2">
+                          <label className="field">
+                            <span>Повторення</span>
+                            <select
+                              className="input"
+                              value={form.payload.repeat.type}
+                              onChange={(e) =>
+                                setPayload("repeat", {
+                                  ...form.payload.repeat,
+                                  type: e.target.value,
+                                })
+                              }
+                            >
+                              <option value="none">Не повторювати</option>
+                              <option value="daily">Щодня</option>
+                              <option value="weekly">Щотижня</option>
+                              <option value="monthly">Щомісяця</option>
+                              <option value="yearly">Щороку</option>
+                              <option value="custom">Кожні N днів</option>
+                            </select>
+                          </label>
+
+                          {form.payload.repeat.type === "custom" && (
+                            <label className="field">
+                              <span>Кількість днів</span>
+                              <input
+                                className="input"
+                                type="number"
+                                min="2"
+                                value={form.payload.repeat.interval}
+                                onChange={(e) =>
+                                  setPayload("repeat", {
+                                    ...form.payload.repeat,
+                                    interval: Number(e.target.value),
+                                  })
+                                }
+                              />
+                            </label>
+                          )}
+                        </div>
+                      </div>
+
+                  {error && <div className="tp-error">{error}</div>}
+
+                  <div className="tp-modal__foot">
+                    <button className="btn ghost" type="button" onClick={() => setModalOpen(false)}>
+                      Скасувати
+                    </button>
+                    <button className="btn primary" type="submit" disabled={busyId !== null}>
+                      {form.id ? "Зберегти" : "Створити"}
+                    </button>
+                  </div>
+                </form>
               </div>
-            ))
-          ) : (
-            <div className="tp-empty">Поки що немає шаблонів</div>
+            </div>
           )}
         </div>
 
-      {modalOpen && (
-        <div className="tp-modal">
-          <div className="tp-modal__dialog card">
-            <div className="tp-modal__head">
-              <h2>{form.id ? "Редагувати шаблон" : "Новий шаблон"}</h2>
-              <button className="btn xs ghost" onClick={() => setModalOpen(false)}>✖</button>
-            </div>
-
-            <form onSubmit={onSubmit} className="tp-modal__body">
-              <VoiceInput endpoint="/templates/voice" onResult={handleVoiceTemplate} />
-              <label className="field">
-                <span>Назва шаблону*</span>
-                <input
-                  className="input"
-                  value={form.name}
-                  onChange={(e) => setForm((s) => ({ ...s, name: e.target.value }))}
-                  placeholder="Наприклад: Щоденний результат"
-                  required
-                />
-              </label>
-
-              <div className="group">
-                <div className="group-title">Значення полів</div>
-
-                    <label className="field">
-                      <span>Назва задачі</span>
-                      <input
-                        className="input"
-                        value={form.payload.title}
-                        onChange={(e) => setPayload("title", e.target.value)}
-                      />
-                    </label>
-
-                    <label className="field">
-                      <span>Очікуваний результат</span>
-                      <textarea
-                        className="input"
-                        rows={3}
-                        value={form.payload.expected_result}
-                        onChange={(e) => setPayload("expected_result", e.target.value)}
-                      />
-                    </label>
-
-                    <label className="field">
-                      <span>Результат</span>
-                      <input
-                        className="input"
-                        value={form.payload.result}
-                        onChange={(e) => setPayload("result", e.target.value)}
-                      />
-                    </label>
-
-                    <label className="field">
-                      <span>Тип</span>
-                      <select
-                        className="input"
-                        value={form.payload.type}
-                        onChange={(e) => setPayload("type", e.target.value)}
-                      >
-                        <option value="важлива термінова">Важлива - термінова</option>
-                        <option value="важлива нетермінова">Важлива - не термінова</option>
-                        <option value="неважлива термінова">Неважлива - термінова</option>
-                        <option value="неважлива нетермінова">Неважлива - нетермінова</option>
-                      </select>
-                    </label>
-
-                <div className="row2">
-                      <label className="field">
-                        <span>Запланований час</span>
-                        <input
-                          className="input"
-                          type="time"
-                          value={form.payload.planned_time}
-                          onChange={(e) => setPayload("planned_time", e.target.value)}
-                        />
-                      </label>
-
-                      <label className="field">
-                        <span>Фактичний час</span>
-                        <input
-                          className="input"
-                          type="time"
-                          value={form.payload.actual_time}
-                          onChange={(e) => setPayload("actual_time", e.target.value)}
-                        />
-                      </label>
-                    </div>
-
-                    <label className="field">
-                      <span>Хто назначив</span>
-                      <input
-                        className="input"
-                        value={form.payload.manager}
-                        onChange={(e) => setPayload("manager", e.target.value)}
-                      />
-                    </label>
-
-                    <label className="field">
-                      <span>Коментарі</span>
-                      <input
-                        className="input"
-                        value={form.payload.comments}
-                        onChange={(e) => setPayload("comments", e.target.value)}
-                      />
-                    </label>
-
-                    <label className="field">
-                      <span>Результат</span>
-                      <select
-                        className="input"
-                        value={form.payload.resultId}
-                        onChange={(e) => setPayload("resultId", e.target.value)}
-                      >
-                        <option value="">—</option>
-                        {results.map((r) => (
-                          <option key={r.id} value={r.id}>
-                            {r.title}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-
-                    <div className="row2">
-                      <label className="field">
-                        <span>Повторення</span>
-                        <select
-                          className="input"
-                          value={form.payload.repeat.type}
-                          onChange={(e) =>
-                            setPayload("repeat", {
-                              ...form.payload.repeat,
-                              type: e.target.value,
-                            })
-                          }
-                        >
-                          <option value="none">Не повторювати</option>
-                          <option value="daily">Щодня</option>
-                          <option value="weekly">Щотижня</option>
-                          <option value="monthly">Щомісяця</option>
-                          <option value="yearly">Щороку</option>
-                          <option value="custom">Кожні N днів</option>
-                        </select>
-                      </label>
-
-                      {form.payload.repeat.type === "custom" && (
-                        <label className="field">
-                          <span>Кількість днів</span>
-                          <input
-                            className="input"
-                            type="number"
-                            min="2"
-                            value={form.payload.repeat.interval}
-                            onChange={(e) =>
-                              setPayload("repeat", {
-                                ...form.payload.repeat,
-                                interval: Number(e.target.value),
-                              })
-                            }
-                          />
-                        </label>
-                      )}
-                    </div>
-                  </div>
-
-              {error && <div className="tp-error">{error}</div>}
-
-              <div className="tp-modal__foot">
-                <button className="btn ghost" type="button" onClick={() => setModalOpen(false)}>
-                  Скасувати
-                </button>
-                <button className="btn primary" type="submit" disabled={busyId !== null}>
-                  {form.id ? "Зберегти" : "Створити"}
-                </button>
-              </div>
-            </form>
+        <aside className="tp-side">
+          <button className="btn" onClick={openCreate}>Створити шаблон з результату</button>
+          <div className="tp-results-list">
+            {results.map((r) => (
+              <button key={r.id} className="tp-result" onClick={() => openCreateFromResult(r)}>
+                {r.title}
+              </button>
+            ))}
           </div>
-        </div>
-      )}
+        </aside>
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- show list of results on templates page sidebar
- allow creating template prefilled with clicked result
- adjust styles for new sidebar layout

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b88029733c83328db31ec5a5478144