### PR TITLE
Додати перемикач вигляду для оргструктури

### DIFF
--- a/src/modules/org/pages/OrgPage.css
+++ b/src/modules/org/pages/OrgPage.css
@@ -6,6 +6,17 @@
   min-height: calc(100dvh - var(--header-h) - var(--footer-h));
 }
 
+.org-page-header{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  margin-bottom:12px;
+}
+
+.org-view-switch{ display:flex; gap:8px; }
+
+.org-table-view{ padding:12px; }
+
 .org-left{
   padding:12px;
   border-right:1px solid var(--border);

--- a/src/modules/org/pages/OrgPage.jsx
+++ b/src/modules/org/pages/OrgPage.jsx
@@ -21,6 +21,7 @@ export default function OrgPage() {
   const [filters, setFilters] = useState({ q: "", divisionId: "any", departmentId: "any", role: "any" });
   const [highlightIds, setHighlightIds] = useState(new Set());
   const [expanded, setExpanded] = useState(() => loadExpanded());
+  const [view, setView] = useState("scheme");
 
   // пошук у лівій панелі -> підсвітити вузли на канвасі
   const handleSearch = (q) => {
@@ -100,34 +101,59 @@ export default function OrgPage() {
     return arr;
     }, [tree]);
 
-  return (
+  const leftPanel = (
+    <OrgLeftPanel
+      positions={filteredPositions}
+      divisions={divisions}
+      departments={departments}
+      filters={filters}
+      onFiltersChange={setFilters}
+      onSearch={handleSearch}
+      onUpdatePosition={handleUpdatePosition}
+      onCreatePosition={handleCreatePosition}
+      onCreateDepartment={handleCreateDepartment}
+      onFocusPosition={handleFocusPosition}
+    />
+  );
 
-    <div className="org-layout">
-      <aside className="org-left card">
-        <OrgLeftPanel
-          positions={filteredPositions}
-          divisions={divisions}
-          departments={departments}
-          filters={filters}
-          onFiltersChange={setFilters}
-          onSearch={handleSearch}
-          onUpdatePosition={handleUpdatePosition}
-          onCreatePosition={handleCreatePosition}
-          onCreateDepartment={handleCreateDepartment}
-          onFocusPosition={handleFocusPosition}
-        />
-      </aside>
-      <main className="org-canvas">
-        <OrgCanvas
-          tree={tree}
-          expanded={expanded}
-          onToggleExpand={toggleExpand}
-          highlightIds={highlightIds}
-          onUpdateUnit={handleUpdateUnit}
-          onMove={handleMove}
-          onReplaceUser={handleReplaceUser}
-        />
-      </main>
+  return (
+    <div>
+      <div className="org-page-header">
+        <h2>Оргструктура</h2>
+        <div className="org-view-switch">
+          <button
+            className={view === "scheme" ? "btn" : "btn ghost"}
+            onClick={() => setView("scheme")}
+          >
+            Схема
+          </button>
+          <button
+            className={view === "table" ? "btn" : "btn ghost"}
+            onClick={() => setView("table")}
+          >
+            Таблиця
+          </button>
+        </div>
+      </div>
+
+      {view === "scheme" ? (
+        <div className="org-layout">
+          <aside className="org-left card">{leftPanel}</aside>
+          <main className="org-canvas">
+            <OrgCanvas
+              tree={tree}
+              expanded={expanded}
+              onToggleExpand={toggleExpand}
+              highlightIds={highlightIds}
+              onUpdateUnit={handleUpdateUnit}
+              onMove={handleMove}
+              onReplaceUser={handleReplaceUser}
+            />
+          </main>
+        </div>
+      ) : (
+        <div className="org-table-view">{leftPanel}</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Опис
- додано стан `view` для сторінки оргструктури
- додано заголовок з кнопками перемикання між таблицею та схемою
- умова відображення таблиці або `OrgCanvas` залежно від вибраного вигляду

## Тестування
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b884fd5e4c8332a0640db2f9e5a03d