### PR TITLE
feat(org): add department and position forms

### DIFF
--- a/src/modules/org/components/DepartmentForm.jsx
+++ b/src/modules/org/components/DepartmentForm.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+
+/**
+ * Формa додавання відділу.
+ * Вимагає назву, ЦКП та відповідального.
+ */
+export default function DepartmentForm({ divisions = [], onSubmit, onCancel }) {
+  const [form, setForm] = useState({
+    name: "",
+    productValue: "",
+    divisionId: divisions[0]?.id || "",
+    head: "",
+  });
+  const [saving, setSaving] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!onSubmit) return;
+    setSaving(true);
+    try {
+      const head = form.head ? { name: form.head } : null;
+      await onSubmit({
+        name: form.name,
+        divisionId: form.divisionId,
+        productValue: form.productValue,
+        head,
+      });
+      setForm({ name: "", productValue: "", divisionId: divisions[0]?.id || "", head: "" });
+      onCancel && onCancel();
+    } catch {
+      alert("Помилка створення відділу");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form className="olp-tr" onSubmit={handleSubmit}>
+      <div className="name">
+        <input
+          className="input"
+          name="name"
+          required
+          placeholder="Назва"
+          value={form.name}
+          onChange={handleChange}
+        />
+        <input
+          className="input"
+          name="productValue"
+          required
+          placeholder="ЦКП"
+          value={form.productValue}
+          onChange={handleChange}
+          style={{ marginTop: 4 }}
+        />
+      </div>
+      <div className="managers">
+        <input
+          className="input"
+          name="head"
+          required
+          placeholder="Відповідальний"
+          value={form.head}
+          onChange={handleChange}
+        />
+      </div>
+      <div className="dept">
+        <select
+          className="input"
+          name="divisionId"
+          required
+          value={form.divisionId}
+          onChange={handleChange}
+        >
+          {divisions.map((d) => (
+            <option key={d.id} value={d.id}>
+              {d.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="actions">
+        <button className="btn" type="submit" disabled={saving}>
+          {saving ? "…" : "Зберегти"}
+        </button>
+        {onCancel && (
+          <button className="btn ghost" type="button" onClick={onCancel}>
+            Скасувати
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}
+

--- a/src/modules/org/components/OrgLeftPanel.jsx
+++ b/src/modules/org/components/OrgLeftPanel.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import PositionForm from "./PositionForm";
+import DepartmentForm from "./DepartmentForm";
 
 /**
  * props:
@@ -20,45 +22,16 @@ export default function OrgLeftPanel({
 }) {
   const [showPosForm, setShowPosForm] = useState(false);
   const [showDepForm, setShowDepForm] = useState(false);
-  const [posForm, setPosForm] = useState({ title: "", departmentId: departments[0]?.id || "", managers: "" });
-  const [depForm, setDepForm] = useState({ name: "", divisionId: divisions[0]?.id || "", head: "" });
-  const [savingPos, setSavingPos] = useState(false);
-  const [savingDep, setSavingDep] = useState(false);
-
-  const submitPos = async (e) => {
-    e.preventDefault();
+  const handlePositionSubmit = async (data) => {
     if (!onCreatePosition) return;
-    setSavingPos(true);
-    try {
-      const managers = posForm.managers
-        .split(",")
-        .map((s, i) => s.trim())
-        .filter(Boolean)
-        .map((name, i) => ({ id: `tmp-${i}`, name }));
-      await onCreatePosition({ title: posForm.title, departmentId: posForm.departmentId, managers });
-      setPosForm({ title: "", departmentId: departments[0]?.id || "", managers: "" });
-      setShowPosForm(false);
-    } catch {
-      alert("Помилка створення посади");
-    } finally {
-      setSavingPos(false);
-    }
+    await onCreatePosition(data);
+    setShowPosForm(false);
   };
 
-  const submitDep = async (e) => {
-    e.preventDefault();
+  const handleDepartmentSubmit = async (data) => {
     if (!onCreateDepartment) return;
-    setSavingDep(true);
-    try {
-      const head = depForm.head ? { name: depForm.head } : null;
-      await onCreateDepartment({ name: depForm.name, divisionId: depForm.divisionId, head });
-      setDepForm({ name: "", divisionId: divisions[0]?.id || "", head: "" });
-      setShowDepForm(false);
-    } catch {
-      alert("Помилка створення відділу");
-    } finally {
-      setSavingDep(false);
-    }
+    await onCreateDepartment(data);
+    setShowDepForm(false);
   };
 
   return (
@@ -123,41 +96,19 @@ export default function OrgLeftPanel({
         </div>
 
         {showPosForm && (
-          <form className="olp-tr" onSubmit={submitPos}>
-            <div className="name">
-              <input className="input" required value={posForm.title} onChange={(e)=>setPosForm({...posForm,title:e.target.value})} />
-            </div>
-            <div className="managers">
-              <input className="input" placeholder="ПІБ керівників" value={posForm.managers} onChange={(e)=>setPosForm({...posForm,managers:e.target.value})} />
-            </div>
-            <div className="dept">
-              <select className="input" required value={posForm.departmentId} onChange={(e)=>setPosForm({...posForm,departmentId:e.target.value})}>
-                {departments.map(d=> <option key={d.id} value={d.id}>{d.name}</option>)}
-              </select>
-            </div>
-            <div className="actions">
-              <button className="btn" type="submit" disabled={savingPos}>{savingPos?"…":"Зберегти"}</button>
-            </div>
-          </form>
+          <PositionForm
+            departments={departments}
+            onSubmit={handlePositionSubmit}
+            onCancel={() => setShowPosForm(false)}
+          />
         )}
 
         {showDepForm && (
-          <form className="olp-tr" onSubmit={submitDep}>
-            <div className="name">
-              <input className="input" required value={depForm.name} onChange={(e)=>setDepForm({...depForm,name:e.target.value})} />
-            </div>
-            <div className="managers">
-              <input className="input" placeholder="Керівник" value={depForm.head} onChange={(e)=>setDepForm({...depForm,head:e.target.value})} />
-            </div>
-            <div className="dept">
-              <select className="input" required value={depForm.divisionId} onChange={(e)=>setDepForm({...depForm,divisionId:e.target.value})}>
-                {divisions.map(d=> <option key={d.id} value={d.id}>{d.name}</option>)}
-              </select>
-            </div>
-            <div className="actions">
-              <button className="btn" type="submit" disabled={savingDep}>{savingDep?"…":"Зберегти"}</button>
-            </div>
-          </form>
+          <DepartmentForm
+            divisions={divisions}
+            onSubmit={handleDepartmentSubmit}
+            onCancel={() => setShowDepForm(false)}
+          />
         )}
 
         {positions.map(p => (

--- a/src/modules/org/components/PositionForm.jsx
+++ b/src/modules/org/components/PositionForm.jsx
@@ -1,0 +1,105 @@
+import React, { useState } from "react";
+
+/**
+ * Формa додавання посади.
+ * Вимагає назву, ЦКП та відповідальних.
+ */
+export default function PositionForm({ departments = [], onSubmit, onCancel }) {
+  const [form, setForm] = useState({
+    title: "",
+    productValue: "",
+    departmentId: departments[0]?.id || "",
+    managers: "",
+  });
+  const [saving, setSaving] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!onSubmit) return;
+    setSaving(true);
+    try {
+      const managers = form.managers
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map((name, i) => ({ id: `tmp-${i}`, name }));
+      await onSubmit({
+        title: form.title,
+        departmentId: form.departmentId,
+        productValue: form.productValue,
+        managers,
+      });
+      setForm({ title: "", productValue: "", departmentId: departments[0]?.id || "", managers: "" });
+      onCancel && onCancel();
+    } catch {
+      alert("Помилка створення посади");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form className="olp-tr" onSubmit={handleSubmit}>
+      <div className="name">
+        <input
+          className="input"
+          name="title"
+          required
+          placeholder="Назва"
+          value={form.title}
+          onChange={handleChange}
+        />
+        <input
+          className="input"
+          name="productValue"
+          required
+          placeholder="ЦКП"
+          value={form.productValue}
+          onChange={handleChange}
+          style={{ marginTop: 4 }}
+        />
+      </div>
+      <div className="managers">
+        <input
+          className="input"
+          name="managers"
+          required
+          placeholder="Відповідальні (через кому)"
+          value={form.managers}
+          onChange={handleChange}
+        />
+      </div>
+      <div className="dept">
+        <select
+          className="input"
+          name="departmentId"
+          required
+          value={form.departmentId}
+          onChange={handleChange}
+        >
+          {departments.map((d) => (
+            <option key={d.id} value={d.id}>
+              {d.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="actions">
+        <button className="btn" type="submit" disabled={saving}>
+          {saving ? "…" : "Зберегти"}
+        </button>
+        {onCancel && (
+          <button className="btn ghost" type="button" onClick={onCancel}>
+            Скасувати
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}
+

--- a/src/modules/org/pages/OrgPage.jsx
+++ b/src/modules/org/pages/OrgPage.jsx
@@ -236,7 +236,7 @@ function addPosition(tree, p) {
   const next = JSON.parse(JSON.stringify(tree));
   next.forEach(div => div.departments.forEach(dep => {
     if (dep.id === p.departmentId) {
-      dep.employees.push({ id: p.id, type: "position", title: p.title, user: p.user, isManager: p.isManager });
+      dep.employees.push({ id: p.id, type: "position", title: p.title, user: p.user, isManager: p.isManager, productValue: p.productValue || "" });
     }
   }));
   return next;


### PR DESCRIPTION
## Summary
- add reusable DepartmentForm and PositionForm components with required field validation
- wire forms into OrgPage sidebar to create departments and positions
- store position productValue in org tree

## Testing
- `npm test --silent -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b8850139d8833292ae16d9023ea737