### PR TITLE
feat: add org API helpers

### DIFF
--- a/src/services/api/org.js
+++ b/src/services/api/org.js
@@ -1,7 +1,24 @@
 import api from "../api";
 
+export const getTree = () => api.get("/org/tree").then(r => r.data);
+export const getFlat = () => api.get("/org/positions").then(r => r.data);
+
 export const createPosition = (data) => api.post("/org/position", data).then(r => r.data);
 export const createDepartment = (data) => api.post("/org/department", data).then(r => r.data);
 export const updatePosition = (id, patch) => api.patch(`/org/position/${id}`, patch).then(r => r.data);
+export const updateUnit = (id, patch) => api.patch(`/org/unit/${id}`, patch).then(r => r.data);
+export const moveEntity = (data) => api.patch("/org/move", data).then(r => r.data);
+export const deleteEntity = (entity, id) => api.delete(`/org/${entity}/${id}`).then(r => r.data);
+export const replaceUser = (id, data) => api.patch(`/org/position/${id}/replaceUser`, data).then(r => r.data);
 
-export default { createPosition, createDepartment, updatePosition };
+export default {
+  getTree,
+  getFlat,
+  createPosition,
+  createDepartment,
+  updatePosition,
+  updateUnit,
+  moveEntity,
+  deleteEntity,
+  replaceUser,
+};


### PR DESCRIPTION
## Summary
- add organization API helpers for tree and position operations
- wire OrgPage to new API helpers

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b88501fb948332a48128c6dd722f85