### PR TITLE
Додано деталі Telegram груп з активностями

### DIFF
--- a/src/modules/telegram/api/telegram.js
+++ b/src/modules/telegram/api/telegram.js
@@ -18,6 +18,11 @@ export const fetchGroups = async (companyId) => {
     return r.data || [];
 };
 
+export const fetchGroup = async (id, companyId) => {
+    const r = await api.get(`/telegram/groups/${id}?company_id=${companyId}`);
+    return r.data;
+};
+
 export const fetchUsers = async (companyId) => {
     const r = await api.get(`/telegram/users?company_id=${companyId}`);
     const items = r.data?.items || r.data || [];

--- a/src/modules/telegram/components/TelegramGroupList.jsx
+++ b/src/modules/telegram/components/TelegramGroupList.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 export default function TelegramGroupList({ groups = [], onRefreshAdmins }) {
     return (
@@ -15,7 +16,9 @@ export default function TelegramGroupList({ groups = [], onRefreshAdmins }) {
             <tbody>
                 {groups.map((g) => (
                     <tr key={g.id}>
-                        <td>{g.title}</td>
+                        <td>
+                            <Link to={`/telegram/groups/${g.id}`}>{g.title}</Link>
+                        </td>
                         <td>{g.chat_id}</td>
                         <td>{g.is_active ? "активна" : ""}</td>
                         <td>{g.linked_at}</td>

--- a/src/modules/telegram/pages/TelegramGroupDetails.jsx
+++ b/src/modules/telegram/pages/TelegramGroupDetails.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import Layout from "../../../components/layout/Layout";
+import { useCompany } from "../../../context/CompanyContext";
+import { fetchGroup } from "../api/telegram";
+
+export default function TelegramGroupDetails() {
+    const { id } = useParams();
+    const { activeCompany } = useCompany();
+    const [group, setGroup] = useState(null);
+    const [activities, setActivities] = useState([]);
+    const [showAll, setShowAll] = useState(false);
+
+    useEffect(() => {
+        if (!id || !activeCompany?.id) return;
+        loadGroup(id, activeCompany.id);
+    }, [id, activeCompany]);
+
+    const loadGroup = async (gid, companyId) => {
+        try {
+            const data = await fetchGroup(gid, companyId);
+            setGroup(data || null);
+            setActivities(data?.activities || []);
+        } catch (e) {
+            console.error("Помилка завантаження групи", e);
+        }
+    };
+
+    const displayed = showAll ? activities : activities.slice(0, 10);
+
+    return (
+        <Layout>
+            <div className="telegram-page">
+                <h2>{group?.title || "Група"}</h2>
+                <section>
+                    <h3>Активності</h3>
+                    <table className="table">
+                        <thead>
+                            <tr>
+                                <th>Дата</th>
+                                <th>Тип</th>
+                                <th>Відповідальний</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {displayed.map((a, idx) => (
+                                <tr key={idx}>
+                                    <td>{a.date}</td>
+                                    <td>{a.type}</td>
+                                    <td>{a.responsible}</td>
+                                </tr>
+                            ))}
+                            {displayed.length === 0 && (
+                                <tr>
+                                    <td colSpan="3">Немає активностей</td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </table>
+                    {activities.length > 10 && (
+                        <button className="btn" onClick={() => setShowAll(!showAll)}>
+                            {showAll ? "Показати менше" : "Показати більше"}
+                        </button>
+                    )}
+                </section>
+            </div>
+        </Layout>
+    );
+}

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -15,6 +15,7 @@ import Layout from "../components/layout/Layout";
 import TelegramGroupPage from "../modules/telegram/pages/TelegramGroupPage";
 import TelegramLinkPage from "../modules/telegram/pages/TelegramLinkPage";
 import TelegramGroupsPage from "../modules/telegram/pages/TelegramGroupsPage";
+import TelegramGroupDetails from "../modules/telegram/pages/TelegramGroupDetails";
 import TelegramUsersPage from "../modules/telegram/pages/TelegramUsersPage";
 import InstructionsPage from "../modules/instructions/pages/InstructionsPage";
 import LoginPage from "../modules/auth/pages/LoginPage";
@@ -161,6 +162,14 @@ export default function AppRouter() {
                     element={
                         <RequireAuth>
                             <TelegramGroupsPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/telegram/groups/:id"
+                    element={
+                        <RequireAuth>
+                            <TelegramGroupDetails />
                         </RequireAuth>
                     }
                 />


### PR DESCRIPTION
## Опис
- розширено API для отримання групи та останніх активностей
- додано сторінку перегляду групи з переліком активностей
- забезпечено обмеження списку активностей для уникнення перевантаження

## Тестування
- `npm test -- --watchAll=false` (очікувано немає тестів)


------
https://chatgpt.com/codex/tasks/task_e_68b885aec20c833297ddf892ea8ea7b5