### PR TITLE
feat: manage telegram group members

### DIFF
--- a/src/modules/telegram/api/telegram.js
+++ b/src/modules/telegram/api/telegram.js
@@ -18,8 +18,12 @@ export const fetchGroups = async (companyId) => {
     return r.data || [];
 };
 
-export const fetchUsers = async (companyId) => {
-    const r = await api.get(`/telegram/users?company_id=${companyId}`);
+export const fetchUsers = async (companyId, params = {}) => {
+    const searchParams = new URLSearchParams();
+    if (companyId) searchParams.append("company_id", companyId);
+    if (params.q) searchParams.append("q", params.q);
+    if (params.group_id) searchParams.append("group_id", params.group_id);
+    const r = await api.get(`/telegram/users?${searchParams.toString()}`);
     const items = r.data?.items || r.data || [];
     return items;
 };
@@ -31,5 +35,10 @@ export const updateUser = async (id, payload) => {
 
 export const refreshGroupAdmins = async (id) => {
     const r = await api.post(`/telegram/groups/${id}/refresh-admins`);
+    return r.data;
+};
+
+export const updateGroupMembers = async (groupId, payload) => {
+    const r = await api.put(`/telegram/groups/${groupId}/members`, payload);
     return r.data;
 };

--- a/src/modules/telegram/components/TelegramGroupDetails.jsx
+++ b/src/modules/telegram/components/TelegramGroupDetails.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from "react";
+import { fetchUsers, updateGroupMembers } from "../api/telegram";
+import { useCompany } from "../../../context/CompanyContext";
+
+export default function TelegramGroupDetails({ group }) {
+    const { activeCompany } = useCompany();
+    const [members, setMembers] = useState([]);
+    const [search, setSearch] = useState({});
+    const [results, setResults] = useState({});
+
+    useEffect(() => {
+        if (!group?.id || !activeCompany?.id) return;
+        loadMembers(group.id, activeCompany.id);
+    }, [group, activeCompany]);
+
+    const loadMembers = async (groupId, companyId) => {
+        try {
+            const data = await fetchUsers(companyId, { group_id: groupId });
+            setMembers(data);
+        } catch (e) {
+            console.error("Помилка завантаження учасників", e);
+        }
+    };
+
+    const handleSearch = async (memberId, value) => {
+        setSearch((prev) => ({ ...prev, [memberId]: value }));
+        if (!value || value.length < 2) {
+            setResults((prev) => ({ ...prev, [memberId]: [] }));
+            return;
+        }
+        try {
+            const data = await fetchUsers(activeCompany?.id, { q: value });
+            setResults((prev) => ({ ...prev, [memberId]: data }));
+        } catch (e) {
+            console.error("Помилка пошуку працівників", e);
+        }
+    };
+
+    const linkMember = async (memberId, employee) => {
+        try {
+            await updateGroupMembers(group.id, {
+                user_id: memberId,
+                employee_id: employee.id,
+            });
+            setMembers((prev) =>
+                prev.map((m) =>
+                    m.id === memberId
+                        ? {
+                              ...m,
+                              employee_id: employee.id,
+                              employee_name: employee.name || employee.display_name,
+                          }
+                        : m
+                )
+            );
+            setSearch((prev) => ({ ...prev, [memberId]: "" }));
+            setResults((prev) => ({ ...prev, [memberId]: [] }));
+        } catch (e) {
+            console.error("Помилка прив'язки", e);
+        }
+    };
+
+    const removeMember = async (memberId) => {
+        try {
+            await updateGroupMembers(group.id, { user_id: memberId, remove: true });
+            setMembers((prev) => prev.filter((m) => m.id !== memberId));
+        } catch (e) {
+            console.error("Помилка видалення", e);
+        }
+    };
+
+    if (!group) return null;
+
+    return (
+        <div>
+            <h3>Учасники групи: {group.title}</h3>
+            <ul>
+                {members.map((m) => (
+                    <li key={m.id} style={{ marginBottom: "1rem" }}>
+                        <div>
+                            {m.display_name || m.username}
+                            {m.employee_id && m.employee_name && (
+                                <span> — {m.employee_name}</span>
+                            )}
+                        </div>
+                        {!m.employee_id && (
+                            <div>
+                                <input
+                                    type="text"
+                                    value={search[m.id] || ""}
+                                    onChange={(e) => handleSearch(m.id, e.target.value)}
+                                    placeholder="Пошук працівника"
+                                />
+                                {results[m.id] && results[m.id].length > 0 && (
+                                    <ul>
+                                        {results[m.id].map((emp) => (
+                                            <li key={emp.id}>
+                                                <button
+                                                    className="btn"
+                                                    onClick={() => linkMember(m.id, emp)}
+                                                >
+                                                    {emp.name || emp.display_name}
+                                                </button>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </div>
+                        )}
+                        <button className="btn" onClick={() => removeMember(m.id)}>
+                            Видалити
+                        </button>
+                    </li>
+                ))}
+                {members.length === 0 && <li>Учасників немає</li>}
+            </ul>
+        </div>
+    );
+}
+


### PR DESCRIPTION
## Summary
- розширено `fetchUsers` та додано `updateGroupMembers` для оновлення складу групи
- створено компонент `TelegramGroupDetails` із пошуком працівників, прив'язкою та видаленням учасників

## Testing
- `npm test -- --runInBand --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b8859def1083328936cf7a25540d41