### PR TITLE
feat: add role-based permissions to org components

### DIFF
--- a/src/modules/org/components/OrgCanvas.jsx
+++ b/src/modules/org/components/OrgCanvas.jsx
@@ -13,7 +13,8 @@ import OrgNode from "./OrgNode";
  */
 export default function OrgCanvas({
   tree, expanded, onToggleExpand, highlightIds,
-  onUpdateUnit, onMove, onReplaceUser
+  onUpdateUnit, onMove, onReplaceUser,
+  canEdit = false
 }) {
   const viewportRef = useRef(null);
   const [zoom, setZoom] = useState(1);
@@ -61,6 +62,7 @@ export default function OrgCanvas({
               onUpdateUnit={onUpdateUnit}
               onMove={onMove}
               onReplaceUser={onReplaceUser}
+              canEdit={canEdit}
             />
           </div>
         ))}

--- a/src/modules/org/components/OrgLeftPanel.jsx
+++ b/src/modules/org/components/OrgLeftPanel.jsx
@@ -16,7 +16,8 @@ import React, { useState } from "react";
 export default function OrgLeftPanel({
   positions, divisions, departments, filters,
   onFiltersChange, onSearch, onUpdatePosition,
-  onCreatePosition, onCreateDepartment, onFocusPosition
+  onCreatePosition, onCreateDepartment, onFocusPosition,
+  canEdit = false
 }) {
   const [showPosForm, setShowPosForm] = useState(false);
   const [showDepForm, setShowDepForm] = useState(false);
@@ -109,10 +110,12 @@ export default function OrgLeftPanel({
         </div>
       </div>
 
-      <div className="olp-actions">
-        <button className="btn ghost" onClick={()=>{ setShowPosForm(p=>!p); setShowDepForm(false); }}>Додати посаду</button>
-        <button className="btn ghost" onClick={()=>{ setShowDepForm(p=>!p); setShowPosForm(false); }}>Додати відділ</button>
-      </div>
+      {canEdit && (
+        <div className="olp-actions">
+          <button className="btn ghost" onClick={()=>{ setShowPosForm(p=>!p); setShowDepForm(false); }}>Додати посаду</button>
+          <button className="btn ghost" onClick={()=>{ setShowDepForm(p=>!p); setShowPosForm(false); }}>Додати відділ</button>
+        </div>
+      )}
 
       <div className="olp-table">
         <div className="olp-th">
@@ -122,7 +125,7 @@ export default function OrgLeftPanel({
           <div>Дії</div>
         </div>
 
-        {showPosForm && (
+        {canEdit && showPosForm && (
           <form className="olp-tr" onSubmit={submitPos}>
             <div className="name">
               <input className="input" required value={posForm.title} onChange={(e)=>setPosForm({...posForm,title:e.target.value})} />
@@ -141,7 +144,7 @@ export default function OrgLeftPanel({
           </form>
         )}
 
-        {showDepForm && (
+        {canEdit && showDepForm && (
           <form className="olp-tr" onSubmit={submitDep}>
             <div className="name">
               <input className="input" required value={depForm.name} onChange={(e)=>setDepForm({...depForm,name:e.target.value})} />
@@ -169,11 +172,11 @@ export default function OrgLeftPanel({
 
             <div className="managers">
               <input className="input" placeholder="введіть ПІБ (демо)" defaultValue={(p.managers||[]).map(m=>m.name).join(", ")}
-                onBlur={(e)=>onUpdatePosition && onUpdatePosition(p.id, { managersText: e.target.value })} />
+                onBlur={(e)=>onUpdatePosition && onUpdatePosition(p.id, { managersText: e.target.value })} disabled={!canEdit} />
             </div>
 
             <div className="dept">
-              <select className="input" defaultValue={p.departmentId} onChange={(e)=>onUpdatePosition && onUpdatePosition(p.id, { departmentId: e.target.value })}>
+              <select className="input" defaultValue={p.departmentId} onChange={(e)=>onUpdatePosition && onUpdatePosition(p.id, { departmentId: e.target.value })} disabled={!canEdit}>
                 {departments.map(d=> <option key={d.id} value={d.id}>{d.name}</option>)}
               </select>
             </div>

--- a/src/modules/org/pages/OrgPage.jsx
+++ b/src/modules/org/pages/OrgPage.jsx
@@ -6,6 +6,7 @@ import "./OrgPage.css";
 import OrgLeftPanel from "../components/OrgLeftPanel";
 import OrgCanvas from "../components/OrgCanvas";
 import { createPosition, createDepartment, updatePosition as apiUpdatePosition } from "../../../services/api/org";
+import { useAuth } from "../../../context/AuthContext";
 
 /**
  * OrgPage – контейнер сторінки оргструктури.
@@ -15,6 +16,10 @@ import { createPosition, createDepartment, updatePosition as apiUpdatePosition }
  *   - PATCH/POST/DELETE ... -> передати у хендлери нижче
  */
 export default function OrgPage() {
+  const { user } = useAuth();
+  const role = user?.role || "guest";
+  const canEdit = role === "admin";
+
   // ----- demo state (замінити на дані API)
   const [tree, setTree] = useState(() => demoTree());
   const [positions, setPositions] = useState(() => demoPositions(tree));
@@ -111,10 +116,11 @@ export default function OrgPage() {
           filters={filters}
           onFiltersChange={setFilters}
           onSearch={handleSearch}
-          onUpdatePosition={handleUpdatePosition}
-          onCreatePosition={handleCreatePosition}
-          onCreateDepartment={handleCreateDepartment}
+          onUpdatePosition={canEdit ? handleUpdatePosition : undefined}
+          onCreatePosition={canEdit ? handleCreatePosition : undefined}
+          onCreateDepartment={canEdit ? handleCreateDepartment : undefined}
           onFocusPosition={handleFocusPosition}
+          canEdit={canEdit}
         />
       </aside>
       <main className="org-canvas">
@@ -123,9 +129,10 @@ export default function OrgPage() {
           expanded={expanded}
           onToggleExpand={toggleExpand}
           highlightIds={highlightIds}
-          onUpdateUnit={handleUpdateUnit}
-          onMove={handleMove}
-          onReplaceUser={handleReplaceUser}
+          onUpdateUnit={canEdit ? handleUpdateUnit : undefined}
+          onMove={canEdit ? handleMove : undefined}
+          onReplaceUser={canEdit ? handleReplaceUser : undefined}
+          canEdit={canEdit}
         />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add role-based permissions via `useAuth` in OrgPage
- propagate `canEdit` prop to OrgCanvas and OrgLeftPanel
- conditionally hide/disable CRUD actions in org components

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b885031f1083329148c93080f1c308