### PR TITLE
feat(telegram): add cancel button

### DIFF
--- a/src/modules/telegram/components/TelegramInviteForm.jsx
+++ b/src/modules/telegram/components/TelegramInviteForm.jsx
@@ -7,6 +7,7 @@ export default function TelegramInviteForm({
     onInviteCodeChange,
     onCompanyChange,
     onSubmit,
+    onCancel,
 }) {
     return (
         <form onSubmit={onSubmit} className="link-form">
@@ -26,8 +27,13 @@ export default function TelegramInviteForm({
                 ))}
             </select>
             <button className="btn primary" type="submit">
-                Прив'язати
+                Підключити
             </button>
+            {onCancel && (
+                <button type="button" className="btn" onClick={onCancel}>
+                    Скасувати
+                </button>
+            )}
         </form>
     );
 }

--- a/src/modules/telegram/pages/TelegramGroupsPage.jsx
+++ b/src/modules/telegram/pages/TelegramGroupsPage.jsx
@@ -21,6 +21,7 @@ export default function TelegramGroupsPage() {
     const [companyId, setCompanyId] = useState(activeCompany?.id || "");
     const [groups, setGroups] = useState([]);
     const [pending, setPending] = useState([]);
+    const [showForm, setShowForm] = useState(false);
 
     const companies = user?.companies || [];
 
@@ -75,6 +76,16 @@ export default function TelegramGroupsPage() {
         }
     };
 
+    const handleCancel = () => {
+        setInviteCode("");
+        setShowForm(false);
+        window.dispatchEvent(
+            new CustomEvent("toast", {
+                detail: { type: "info", message: "Прив'язку скасовано" },
+            })
+        );
+    };
+
     const handleRefresh = async (id) => {
         try {
             await refreshGroupAdmins(id);
@@ -90,14 +101,23 @@ export default function TelegramGroupsPage() {
         <Layout>
             <div className="telegram-page">
                 <h2>Telegram групи</h2>
-                <TelegramInviteForm
-                    inviteCode={inviteCode}
-                    companyId={companyId}
-                    companies={companies}
-                    onInviteCodeChange={(v) => setInviteCode(v.toUpperCase())}
-                    onCompanyChange={onCompanyChange}
-                    onSubmit={handleLink}
-                />
+                {showForm ? (
+                    <TelegramInviteForm
+                        inviteCode={inviteCode}
+                        companyId={companyId}
+                        companies={companies}
+                        onInviteCodeChange={(v) => setInviteCode(v.toUpperCase())}
+                        onCompanyChange={onCompanyChange}
+                        onSubmit={handleLink}
+                        onCancel={handleCancel}
+                    />
+                ) : (
+                    <div className="link-form">
+                        <button className="btn primary" onClick={() => setShowForm(true)}>
+                            Підключити
+                        </button>
+                    </div>
+                )}
                 {companyId && (
                     <section>
                         <h3>Очікуючі групи</h3>


### PR DESCRIPTION
## Summary
- add optional cancel action to Telegram invite form
- hide link form after cancel and show toast notification

## Testing
- `CI=true npm test` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b8859fe8a883329d7b01e82d09d19e