### PR TITLE
feat: add default org divisions

### DIFF
--- a/src/modules/org/components/OrgCanvas.css
+++ b/src/modules/org/components/OrgCanvas.css
@@ -10,10 +10,11 @@
   position:relative; width:max-content; min-width:100%; min-height:100%;
   transform-origin: 0 0;
   cursor: grab;
+  display:flex;
 }
 
 .org-canvas-controls{
   position:absolute; top:12px; right:12px; display:flex; gap:6px; z-index:2;
 }
 
-.org-column{ margin:20px; }
+.org-column{ margin:20px; display:flex; flex-direction:column; }

--- a/src/modules/org/components/OrgCanvas.jsx
+++ b/src/modules/org/components/OrgCanvas.jsx
@@ -13,7 +13,7 @@ import OrgNode from "./OrgNode";
  */
 export default function OrgCanvas({
   tree, expanded, onToggleExpand, highlightIds,
-  onUpdateUnit, onMove, onReplaceUser
+  onUpdateUnit, onMove, onReplaceUser, employees
 }) {
   const viewportRef = useRef(null);
   const [zoom, setZoom] = useState(1);
@@ -61,6 +61,7 @@ export default function OrgCanvas({
               onUpdateUnit={onUpdateUnit}
               onMove={onMove}
               onReplaceUser={onReplaceUser}
+              employees={employees}
             />
           </div>
         ))}

--- a/src/modules/org/components/OrgNode.css
+++ b/src/modules/org/components/OrgNode.css
@@ -29,6 +29,16 @@
 }
 .line .k{ color: var(--text-muted); min-width:80px; }
 
+.resp-select{ display:flex; align-items:center; gap:8px; flex:1; }
+.head-avatar{
+  background: var(--primary);
+  color:#000;
+  width:24px; height:24px;
+  border-radius:50%;
+  display:flex; align-items:center; justify-content:center;
+  font-weight:600; font-size:12px;
+}
+
 .unit-actions, .pos-actions{ display:flex; gap:6px; margin-top:8px; flex-wrap:wrap; }
 
 .children{

--- a/src/modules/org/components/OrgNode.jsx
+++ b/src/modules/org/components/OrgNode.jsx
@@ -6,11 +6,14 @@ import React, { useState } from "react";
  */
 export default function OrgNode({
   node, level, expanded, onToggleExpand, highlightIds,
-  onUpdateUnit, onMove, onReplaceUser
+  onUpdateUnit, onMove, onReplaceUser, employees = []
 }) {
   const key = node.id;
   const isOpen = expanded.has(key);
   const isHighlighted = highlightIds?.has(key);
+  const headInitials = node.head?.name
+    ? node.head.name.split(" ").map(n => n[0]).join("").toUpperCase()
+    : "";
 
   // DnD
   const [dragOverState, setDragOverState] = useState(null); // 'ok'|'deny'|null
@@ -87,11 +90,27 @@ export default function OrgNode({
               onBlur={(e)=>onUpdateUnit && onUpdateUnit(node.id, { productValue: e.target.value })}
             />
           </label>
+          <label className="line">
+            <span className="k">Відповідальний</span>
+            <div className="resp-select">
+              <div className="head-avatar">{headInitials || ""}</div>
+              <select
+                className="input"
+                defaultValue=""
+                onChange={(e)=>{
+                  const u = employees.find(u => String(u.id) === e.target.value);
+                  onUpdateUnit && onUpdateUnit(node.id, { head: u || null });
+                }}
+              >
+                <option value="">—</option>
+                {employees.map(u => (
+                  <option key={u.id} value={u.id}>{u.name}</option>
+                ))}
+              </select>
+            </div>
+          </label>
           <div className="unit-actions">
-            <button className="btn ghost">Додати відділ</button>
-            <button className="btn ghost">Додати посаду</button>
-            <button className="btn ghost">Редагувати</button>
-            <button className="btn ghost">Видалити</button>
+            <button className="btn ghost">+</button>
           </div>
         </div>
       )}
@@ -110,6 +129,7 @@ export default function OrgNode({
               onUpdateUnit={onUpdateUnit}
               onMove={onMove}
               onReplaceUser={onReplaceUser}
+              employees={employees}
             />
           ))}
           {node.type === "department" && (node.employees || []).map(p => (
@@ -123,6 +143,7 @@ export default function OrgNode({
               onUpdateUnit={onUpdateUnit}
               onMove={onMove}
               onReplaceUser={onReplaceUser}
+              employees={employees}
             />
           ))}
         </div>

--- a/src/modules/org/pages/OrgPage.jsx
+++ b/src/modules/org/pages/OrgPage.jsx
@@ -7,6 +7,15 @@ import OrgLeftPanel from "../components/OrgLeftPanel";
 import OrgCanvas from "../components/OrgCanvas";
 import { createPosition, createDepartment, updatePosition as apiUpdatePosition, getOrgTree, getOrgPositions } from "../../../services/api/org";
 
+const DEFAULT_TREE = [
+  { id: 1, type: "division", name: "Відділення 1. Зв’язки", head: null, productValue: "", order: 1, departments: [] },
+  { id: 2, type: "division", name: "Відділення 2. Розповсюдження", head: null, productValue: "", order: 2, departments: [] },
+  { id: 3, type: "division", name: "Відділення 3. Виробництво", head: null, productValue: "", order: 3, departments: [] },
+  { id: 4, type: "division", name: "Відділення 4. Технічне забезпечення / Кваліфікація", head: null, productValue: "", order: 4, departments: [] },
+  { id: 5, type: "division", name: "Відділення 5. Фінанси", head: null, productValue: "", order: 5, departments: [] },
+  { id: 6, type: "division", name: "Відділення 6. Управління / Організація", head: null, productValue: "", order: 6, departments: [] },
+  { id: 7, type: "division", name: "Відділення 7. Виконавче керівництво", head: null, productValue: "", order: 7, departments: [] },
+];
 /**
  * OrgPage – контейнер сторінки оргструктури.
  * TODO: PATCH/POST/DELETE ... -> передати у хендлери нижче
@@ -28,7 +37,8 @@ export default function OrgPage() {
           getOrgPositions(),
         ]);
         if (cancelled) return;
-        setTree(parseTree(treeData));
+        const parsedTree = parseTree(treeData);
+        setTree(parsedTree.length ? parsedTree : DEFAULT_TREE);
         setPositions(parsePositions(posData));
       } catch (e) {
         console.error(e);
@@ -118,6 +128,12 @@ export default function OrgPage() {
     return arr;
     }, [tree]);
 
+  const employees = useMemo(() => {
+    const map = new Map();
+    positions.forEach(p => { if (p.user) map.set(p.user.id, p.user); });
+    return [...map.values()];
+  }, [positions]);
+
   const leftPanel = (
     <OrgLeftPanel
       positions={filteredPositions}
@@ -165,6 +181,7 @@ export default function OrgPage() {
               onUpdateUnit={handleUpdateUnit}
               onMove={handleMove}
               onReplaceUser={handleReplaceUser}
+              employees={employees}
             />
           </main>
         </div>


### PR DESCRIPTION
## Summary
- add 7 Hubbard divisions as default org tree
- show responsible avatar, selectable future head, and add button in org nodes
- display org divisions as horizontal columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b88be69aa8833287a67dfe4cfc6886