### PR TITLE
Fix telegram link and wrap BP editor with layout

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -197,7 +197,7 @@ export default function Sidebar({
                         </li>
                         <li>
                             <NavLink
-                                to="/telegram-group"
+                                to="/telegram/groups"
                                 className={({ isActive }) =>
                                     isActive ? "active" : ""
                                 }

--- a/src/modules/bp/pages/BpEditorPage.jsx
+++ b/src/modules/bp/pages/BpEditorPage.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Layout from "../../../components/layout/Layout";
 import BpToolbar from "../components/BpToolbar";
 import BpCanvas from "../components/BpCanvas";
 import BpInspector from "../components/BpInspector";
@@ -6,12 +7,14 @@ import "./BpEditorPage.css";
 
 export default function BpEditorPage() {
     return (
-        <div className="bp-editor-page">
-            <BpToolbar />
-            <div className="bp-editor-main">
-                <BpCanvas />
-                <BpInspector />
+        <Layout>
+            <div className="bp-editor-page">
+                <BpToolbar />
+                <div className="bp-editor-main">
+                    <BpCanvas />
+                    <BpInspector />
+                </div>
             </div>
-        </div>
+        </Layout>
     );
 }


### PR DESCRIPTION
## Summary
- fix sidebar telegram link to open groups page
- wrap business process editor with Layout

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b893d82760833280c92b2c6063d115