### PR TITLE
Оргструктура: відділи в один рядок та кнопка додати відділ

### DIFF
--- a/src/modules/org/components/OrgCanvas.jsx
+++ b/src/modules/org/components/OrgCanvas.jsx
@@ -10,10 +10,11 @@ import OrgNode from "./OrgNode";
  * - onUpdateUnit(id, patch)
  * - onMove({ entity:'department'|'position', id, targetId })
  * - onReplaceUser(positionId, newUser)
+ * - onCreateDepartment(data)
  */
 export default function OrgCanvas({
   tree, expanded, onToggleExpand, highlightIds,
-  onUpdateUnit, onMove, onReplaceUser, employees
+  onUpdateUnit, onMove, onReplaceUser, onCreateDepartment, employees
 }) {
   const viewportRef = useRef(null);
   const [zoom, setZoom] = useState(1);
@@ -61,6 +62,7 @@ export default function OrgCanvas({
               onUpdateUnit={onUpdateUnit}
               onMove={onMove}
               onReplaceUser={onReplaceUser}
+              onCreateDepartment={onCreateDepartment}
               employees={employees}
             />
           </div>

--- a/src/modules/org/components/OrgNode.css
+++ b/src/modules/org/components/OrgNode.css
@@ -11,6 +11,8 @@
   margin:10px;
 }
 
+.org-node.is-division{ max-width:none; }
+
 .org-node .head{
   display:flex; align-items:center; gap:8px; margin-bottom:8px;
 }
@@ -42,7 +44,7 @@
 .unit-actions, .pos-actions{ display:flex; gap:6px; margin-top:8px; flex-wrap:wrap; }
 
 .children{
-  display:flex; flex-wrap:wrap; align-items:flex-start; margin-top:6px; padding-left:18px;
+  display:flex; flex-wrap:nowrap; align-items:flex-start; margin-top:6px; padding-left:18px;
   border-left:2px dashed color-mix(in srgb, var(--navy) 20%, transparent);
 }
 

--- a/src/modules/org/components/OrgNode.jsx
+++ b/src/modules/org/components/OrgNode.jsx
@@ -6,7 +6,8 @@ import React, { useState } from "react";
  */
 export default function OrgNode({
   node, level, expanded, onToggleExpand, highlightIds,
-  onUpdateUnit, onMove, onReplaceUser, employees = []
+  onUpdateUnit, onMove, onReplaceUser, onCreateDepartment,
+  employees = []
 }) {
   const key = node.id;
   const isOpen = expanded.has(key);
@@ -109,9 +110,25 @@ export default function OrgNode({
               </select>
             </div>
           </label>
-          <div className="unit-actions">
-            <button className="btn ghost">+</button>
-          </div>
+          {node.type === "division" && (
+            <div className="unit-actions">
+              <button
+                className="btn ghost"
+                onClick={() => {
+                  const name = prompt("Назва відділу");
+                  if (!name) return;
+                  onCreateDepartment && onCreateDepartment({
+                    name,
+                    divisionId: node.id,
+                    productValue: "",
+                    head: null,
+                  });
+                }}
+              >
+                + Відділ
+              </button>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/modules/org/pages/OrgPage.jsx
+++ b/src/modules/org/pages/OrgPage.jsx
@@ -181,6 +181,7 @@ export default function OrgPage() {
               onUpdateUnit={handleUpdateUnit}
               onMove={handleMove}
               onReplaceUser={handleReplaceUser}
+              onCreateDepartment={handleCreateDepartment}
               employees={employees}
             />
           </main>


### PR DESCRIPTION
## Summary
- розширено блоки відділень і прибрано перенесення дочірніх відділів на новий рядок
- додано кнопку «+ Відділ» у вузлі відділення та прокинуто відповідний обробник через OrgCanvas та OrgPage

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b894ceb37483329d894d66e0ba97cb