### PR TITLE
Add quick task input on DailyTasksPage

### DIFF
--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -25,6 +25,11 @@
   justify-content: center;
 }
 
+.new-task-input {
+  width: 100%;
+  margin: 16px 0;
+}
+
 .muted {
   color: var(--text-muted);
 }

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -38,6 +38,7 @@ export default function DailyTasksPage() {
     const [users, setUsers] = useState([]);
     const [newTaskExecutorId, setNewTaskExecutorId] = useState("");
     const [titleError, setTitleError] = useState(false);
+    const [quickTaskTitle, setQuickTaskTitle] = useState("");
 
     // popover перенесення
     const [rescheduleForId, setRescheduleForId] = useState(null);
@@ -319,6 +320,30 @@ export default function DailyTasksPage() {
         }
     };
 
+    const handleQuickTaskKeyDown = async (e) => {
+        if (e.key !== "Enter" || !quickTaskTitle.trim()) return;
+        const payload = {
+            planned_date: formatDateForApi(selectedDate),
+            title: quickTaskTitle.trim(),
+            type: "важлива нетермінова",
+            expected_time: 30,
+            actual_time: 0,
+            expected_result: "",
+            description: "",
+            manager: userLabel(user) || "",
+            executor_id: user?.id || null,
+            result_id: null,
+            comments: JSON.stringify([]),
+        };
+        try {
+            await api.post(`/tasks`, payload);
+            setQuickTaskTitle("");
+            loadTasks(formatDateForApi(selectedDate), filters);
+        } catch (err) {
+            console.error("Помилка створення задачі", err);
+        }
+    };
+
     // закриття поповера “перенести” по кліку поза ним
     useEffect(() => {
         const onDocClick = (e) => {
@@ -575,6 +600,15 @@ export default function DailyTasksPage() {
                     </div>
                 </div>
             )}
+
+            <input
+                type="text"
+                className="input new-task-input"
+                placeholder="Нова задача…"
+                value={quickTaskTitle}
+                onChange={(e) => setQuickTaskTitle(e.target.value)}
+                onKeyDown={handleQuickTaskKeyDown}
+            />
 
             {tasks.length === 0 ? (
                 <div className="tasks-empty">Задач на сьогодні не додано</div>


### PR DESCRIPTION
## Summary
- add quick task input to DailyTasksPage for fast creation
- post new tasks with default parameters and refresh list
- style quick task input

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b986e52be4833287d8ea91a8e2019c