### PR TITLE
feat: додати ResultsSidebar на сторінку задач

### DIFF
--- a/src/modules/results/components/ResultsSidebar.css
+++ b/src/modules/results/components/ResultsSidebar.css
@@ -1,0 +1,39 @@
+@import "../../../styles/variables.css";
+
+.results-sidebar {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rs-title {
+  margin: 0;
+  font-size: var(--fz-base);
+  font-weight: 600;
+  color: var(--navy);
+}
+
+.rs-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rs-item {
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  transition: background var(--transition), box-shadow var(--transition);
+}
+
+.rs-item:hover {
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
+  box-shadow: var(--shadow-sm);
+}

--- a/src/modules/results/components/ResultsSidebar.jsx
+++ b/src/modules/results/components/ResultsSidebar.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import "./ResultsSidebar.css";
+
+export default function ResultsSidebar({ results = [], onSelectResult }) {
+    return (
+        <aside className="results-sidebar">
+            <h2 className="rs-title">Результати</h2>
+            <div className="rs-list">
+                {results.map((r) => (
+                    <button
+                        key={r.id}
+                        type="button"
+                        className="rs-item"
+                        onClick={() => onSelectResult && onSelectResult(r.id)}
+                    >
+                        {r.title}
+                    </button>
+                ))}
+            </div>
+        </aside>
+    );
+}

--- a/src/modules/tasks/pages/DailyTasksPage.css
+++ b/src/modules/tasks/pages/DailyTasksPage.css
@@ -8,6 +8,19 @@
   width: 100%;
 }
 
+.daily-tasks-layout {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+@media (max-width: 900px) {
+  .daily-tasks-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Заголовок з кнопками навігації дати */
 .tasks-title {
   display: inline-flex;

--- a/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -9,6 +9,7 @@ import { getResults } from "../../results/api/results";
 import { useAuth } from "../../../context/AuthContext";
 import TaskComments from "../components/TaskComments";
 import VoiceInput from "../../../shared/components/VoiceInput";
+import ResultsSidebar from "../../results/components/ResultsSidebar";
 
 export default function DailyTasksPage() {
     const [selectedDate, setSelectedDate] = useState(new Date());
@@ -225,6 +226,11 @@ export default function DailyTasksPage() {
         setSelectedDate((d) => new Date(d.getTime() + 86400000));
     const openDatePicker = () => dateInputRef.current?.showPicker();
 
+    const handleResultSelect = (id) => {
+        setNewTaskResultId(String(id));
+        setIsFormOpen(true);
+    };
+
     useEffect(() => {
         api
             .get(`/tasks/templates`)
@@ -336,6 +342,8 @@ export default function DailyTasksPage() {
 
     return (
         <Layout>
+            <div className="daily-tasks-layout">
+                <div className="daily-tasks-main">
             {/* Заголовок + календар по центру */}
             <div className="page-header">
                 <h1 className="tasks-title">
@@ -846,6 +854,12 @@ export default function DailyTasksPage() {
 
             {/* За бажанням можна повернути плаваючу FAB: */}
             <button type="button" className="fab-add" onClick={() => setIsFormOpen(true)}><FiPlus size={24} /></button>
+                </div>
+                <ResultsSidebar
+                    results={results}
+                    onSelectResult={handleResultSelect}
+                />
+            </div>
         </Layout>
     );
 }


### PR DESCRIPTION
## Summary
- додано компонент ResultsSidebar для відображення активних результатів
- інтегровано ResultsSidebar на сторінці щоденних задач

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b986e8c8548332b240ce0f36398976