### PR TITLE
feat: add results mode and view switcher

### DIFF
--- a/src/modules/results/pages/ResultsPage.css
+++ b/src/modules/results/pages/ResultsPage.css
@@ -13,9 +13,27 @@
   justify-content:space-between;
 }
 
+.results-page__controls{
+  display:flex;
+  justify-content:space-between;
+  flex-wrap:wrap;
+  gap:12px;
+}
+
+.results-modes,
+.results-view{
+  display:flex;
+  gap:8px;
+}
+
 .results-list{
   display:grid;
   gap:0;
+}
+
+.results-table{
+  display:flex;
+  flex-direction:column;
 }
 
 .results-group + .results-group{

--- a/src/modules/results/pages/ResultsPage.jsx
+++ b/src/modules/results/pages/ResultsPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Layout from '../../../components/layout/Layout.jsx';
 import { getResults, getResultTasks } from '../api/results';
 import ResultItem from '../components/ResultItem.jsx';
+import ResultRow from '../components/ResultRow.jsx';
 import ResultDetails from '../components/ResultDetails.jsx';
 import ResultsEmpty from '../components/ResultsEmpty.jsx';
 import ResultForm from '../components/ResultForm.jsx';
@@ -13,12 +14,14 @@ export default function ResultsPage() {
   const [expanded, setExpanded] = useState(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const [parentId, setParentId] = useState(null);
+  const [mode, setMode] = useState('my');
+  const [view, setView] = useState('table');
   const [, setTasksLoading] = useState({});
 
-  const fetchResults = async () => {
+  const fetchResults = async (currentMode = mode) => {
     setLoading(true);
     try {
-      const data = await getResults({ page: 1 });
+      const data = await getResults({ page: 1, mode: currentMode });
       const items = data.items || data || [];
       setResults(items);
     } finally {
@@ -27,8 +30,8 @@ export default function ResultsPage() {
   };
 
   useEffect(() => {
-    fetchResults();
-  }, []);
+    fetchResults(mode);
+  }, [mode]);
 
   const handleSaved = () => {
     setShowAddForm(false);
@@ -85,6 +88,43 @@ export default function ResultsPage() {
           )}
         </div>
 
+        <div className="results-page__controls">
+          <div className="results-modes">
+            <button
+              className={`btn ${mode === 'my' ? 'primary' : 'ghost'}`}
+              onClick={() => setMode('my')}
+            >
+              Мої
+            </button>
+            <button
+              className={`btn ${mode === 'delegated' ? 'primary' : 'ghost'}`}
+              onClick={() => setMode('delegated')}
+            >
+              Делеговані
+            </button>
+            <button
+              className={`btn ${mode === 'subordinates' ? 'primary' : 'ghost'}`}
+              onClick={() => setMode('subordinates')}
+            >
+              Підлеглих
+            </button>
+          </div>
+          <div className="results-view">
+            <button
+              className={`btn ${view === 'table' ? 'primary' : 'ghost'}`}
+              onClick={() => setView('table')}
+            >
+              Таблиця
+            </button>
+            <button
+              className={`btn ${view === 'cards' ? 'primary' : 'ghost'}`}
+              onClick={() => setView('cards')}
+            >
+              Картки
+            </button>
+          </div>
+        </div>
+
         {showAddForm && (
           <ResultForm
             parentId={parentId}
@@ -108,23 +148,43 @@ export default function ResultsPage() {
         )}
 
         {!loading && results.length > 0 && (
-          <div className="results-list">
-            {results.map((r) => (
-              <React.Fragment key={r.id}>
-                <ResultItem
-                  result={r}
-                  expanded={expanded === r.id}
-                  onToggleExpand={toggleExpand}
-                />
-                {expanded === r.id && (
-                  <ResultDetails
+          view === 'cards' ? (
+            <div className="results-list">
+              {results.map((r) => (
+                <React.Fragment key={r.id}>
+                  <ResultItem
                     result={r}
-                    onAddSubresult={handleAddSubresult}
+                    expanded={expanded === r.id}
+                    onToggleExpand={toggleExpand}
                   />
-                )}
-              </React.Fragment>
-            ))}
-          </div>
+                  {expanded === r.id && (
+                    <ResultDetails
+                      result={r}
+                      onAddSubresult={handleAddSubresult}
+                    />
+                  )}
+                </React.Fragment>
+              ))}
+            </div>
+          ) : (
+            <div className="results-table">
+              {results.map((r) => (
+                <React.Fragment key={r.id}>
+                  <ResultRow
+                    result={r}
+                    expanded={expanded === r.id}
+                    onToggleExpand={toggleExpand}
+                  />
+                  {expanded === r.id && (
+                    <ResultDetails
+                      result={r}
+                      onAddSubresult={handleAddSubresult}
+                    />
+                  )}
+                </React.Fragment>
+              ))}
+            </div>
+          )
         )}
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- add mode selection and view toggle on results page
- support table and card presentations
- style controls and table layout

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b986f10524833290443e662efa7893