### PR TITLE
Перехід на нові ендпоінти задач

### DIFF
--- a/src/components/layout/Sidebar/Sidebar.jsx
+++ b/src/components/layout/Sidebar/Sidebar.jsx
@@ -245,7 +245,7 @@ export function RightSidebar() {
     useEffect(() => {
         const today = new Date().toISOString().split("T")[0];
         api
-            .get(`/task/filter?date=${today}`)
+            .get("/tasks", { params: { date: today, mode: "mine" } })
             .then((res) => {
                 const backendTasks = res.data?.tasks || [];
                 const mapped = backendTasks.map((t) => ({
@@ -304,10 +304,7 @@ export function RightSidebar() {
             )
         );
         try {
-            await api.patch(
-                `/task/update-field?id=${id}`,
-                { field: "status", value: newStatus }
-            );
+            await api.patch(`/tasks/${id}/status`, { status: newStatus });
         } catch (e) {
             setTasks((prev) =>
                 prev.map((t) =>

--- a/src/modules/tasks/components/AddTaskRow.jsx
+++ b/src/modules/tasks/components/AddTaskRow.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { createDailyTask } from "../../../services/api/tasks";
+import { createTask } from "../../../services/api/tasks";
 
 /**
  * Компонент для додавання задачі
@@ -22,7 +22,7 @@ export default function AddTaskRow({
     const handleAddNew = async () => {
         if (!newTaskTitle.trim()) return;
         try {
-            await createDailyTask({
+            await createTask({
                 title: newTaskTitle.trim(),
                 date: new Date().toISOString().split("T")[0],
             });

--- a/src/modules/tasks/components/TaskComments.jsx
+++ b/src/modules/tasks/components/TaskComments.jsx
@@ -17,9 +17,8 @@ export default function TaskComments({
         if (!newComment.trim()) return;
         const updated = [...comments, { author, text: newComment, replies: [] }];
         try {
-            await api.patch(`/task/update-field?id=${taskId}`, {
-                field: "comments",
-                value: JSON.stringify(updated),
+            await api.patch(`/tasks/${taskId}`, {
+                comments: JSON.stringify(updated),
             });
             onCommentsChange?.(updated);
             setNewComment("");
@@ -40,9 +39,8 @@ export default function TaskComments({
             };
         }
         try {
-            await api.patch(`/task/update-field?id=${taskId}`, {
-                field: "comments",
-                value: JSON.stringify(updated),
+            await api.patch(`/tasks/${taskId}`, {
+                comments: JSON.stringify(updated),
             });
             onCommentsChange?.(updated);
             setReplyText("");

--- a/src/services/api/tasks.js
+++ b/src/services/api/tasks.js
@@ -1,7 +1,7 @@
 import api from "../api";
 
-export const createDailyTask = async (data) =>
-    (await api.post("/tasks/daily", data)).data;
+export const createTask = async (data) =>
+    (await api.post("/tasks", data)).data;
 
 export const getTaskTemplates = async () =>
     (await api.get("/tasks/templates")).data;


### PR DESCRIPTION
## Summary
- switch task list fetch to GET /tasks with date and mode params
- create tasks via POST /tasks
- update status, date and other fields through dedicated PATCH endpoints

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b986f565788332a7775444803ec494